### PR TITLE
added cmds for installing inventory/kapitan on the manage org page

### DIFF
--- a/imports/ui/pages/org/index.js
+++ b/imports/ui/pages/org/index.js
@@ -159,8 +159,11 @@ Template.OrgSingle.helpers({
     org(){
         return Orgs.findOne({ name: Template.instance().orgName });
     },
-    yamlUrl( org, key ) {
-        return Meteor.absoluteUrl( `/install/${org}/${key}` );
+    inventoryYamlUrl(key){
+        return Meteor.absoluteUrl(`api/install/inventory?orgKey=${key}`);
+    },
+    kapitanYamlUrl(key){
+        return Meteor.absoluteUrl(`api/install/kapitan?orgKey=${key}`);
     },
     disabled() {
         return dirtyFlag.get() ? {} : {disabled: 'disabled'};

--- a/imports/ui/pages/org/page.html
+++ b/imports/ui/pages/org/page.html
@@ -60,13 +60,27 @@
 
                     <div class="form-group row">
                         <label for="org_command" class="col-sm-2 col-form-label">
-                            Install Cluster-updater
+                            Install Inventory
+                        </label>
+                        <div class="col-sm-10">
+                            <div class="input-group">
+                                <code class="form-control text-truncate" id="org_command">kubectl create -f {{inventoryYamlUrl org.apiKey}}</code>
+                                <div class="input-group-append">
+                                    <button class="btn btn-primary copy-button" type="button" data-clipboard-text="kubectl create -f {{inventoryYamlUrl org.apiKey}}">Copy</button>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+
+                    <div class="form-group row">
+                        <label for="org_command" class="col-sm-2 col-form-label">
+                            Install Kapitan
                         </label>
                         <div class="col-sm-10">
                             <div class="input-group mb-3">
-                                <code class="form-control text-truncate" id="org_command">kubectl create -f {{yamlUrl org.name org.apiKey}}</code>
+                                <code class="form-control text-truncate" id="org_command">kubectl create -f {{kapitanYamlUrl org.apiKey}}</code>
                                 <div class="input-group-append">
-                                    <button class="btn btn-primary copy-button" type="button" data-clipboard-text="kubectl create -f {{yamlUrl org.name org.apiKey}}">Copy</button>
+                                    <button class="btn btn-primary copy-button" type="button" data-clipboard-text="kubectl create -f {{kapitanYamlUrl org.apiKey}}">Copy</button>
                                 </div>
                             </div>
                         </div>


### PR DESCRIPTION

![image](https://user-images.githubusercontent.com/20116801/57947303-8609ad80-78ac-11e9-914c-e9900ae0750f.png)

Points to the urls thatll work once https://github.com/razee-io/Razeedash-api/pull/14 is merged

Is the text fine, or do we want it to say something else?

