### PR TITLE
Apikey to orgkeys

### DIFF
--- a/imports/api/org/methods.js
+++ b/imports/api/org/methods.js
@@ -59,11 +59,11 @@ Meteor.methods({
             throw new Meteor.Error(`org "${name}" already exists`);
         }
 
-        var apiKey = `orgApiKey-${uuid()}`;
+        var orgKey = `orgApiKey-${uuid()}`;
         Orgs.insert({
             name,
             creatorUserId: userObj._id,
-            apiKey: apiKey,
+            orgKeys: [orgKey],
             gheOrgId: userOrg.gheOrgId,
             created: new Date(),
             updated: new Date()

--- a/imports/api/resource/methods.js
+++ b/imports/api/resource/methods.js
@@ -35,7 +35,7 @@ Meteor.methods({
         if(!org){
             throw new Meteor.Error(`couldnt find org id "${resource.org_id}" from resource._id "${resource._id}"`);
         }
-        return tokenCrypt.decrypt(resource.data, org.apiKey);
+        return tokenCrypt.decrypt(resource.data, org.orgKeys[0]);
     },
     async getActiveDepsPerService(orgId){
         requireOrgAccess(orgId);

--- a/imports/ui/pages/admin/adminOrgs/index.js
+++ b/imports/ui/pages/admin/adminOrgs/index.js
@@ -46,6 +46,9 @@ Template.AdminOrgsSingle.helpers({
     org(){
         return Orgs.findOne({name: Template.instance().orgName});
     },
+    firstOrgKey(org){
+        return org.orgKeys[0];
+    },
 });
 
 Template.AdminOrgRegister.onCreated(function(){

--- a/imports/ui/pages/admin/adminOrgs/page.html
+++ b/imports/ui/pages/admin/adminOrgs/page.html
@@ -75,10 +75,12 @@
 
             <div class="row no-gutters py-2">
                 <div class="col-12 col-sm-2 font-italic">
-                    Api Key:
+                    Api Keys:
                 </div>
                 <div class="col-10">
-                    <input class="form-control keyDisplay" type="text" value="{{org.apiKey}}" disabled />
+                    {{#each orgKey in org.orgKeys}}
+                        <input class="form-control keyDisplay" type="text" value="{{orgKey}}" disabled />
+                    {{/each}}
                 </div>
             </div>
 
@@ -88,7 +90,7 @@
                 </div>
                 <div class="col-10">
                     <code>
-                        kubectl create -f https://razeedash.oneibmcloud.com/api/v1/orgYml/{{org.apiKey}}
+                        kubectl create -f https://razeedash.oneibmcloud.com/api/v1/orgYml/{{firstOrgKey org}}
                     </code>
                 </div>
             </div>

--- a/imports/ui/pages/org/index.js
+++ b/imports/ui/pages/org/index.js
@@ -165,6 +165,9 @@ Template.OrgSingle.helpers({
     kapitanYamlUrl(key){
         return Meteor.absoluteUrl(`api/install/kapitan?orgKey=${key}`);
     },
+    firstOrgKey(org){
+        return org.orgKeys[0];
+    },
     disabled() {
         return dirtyFlag.get() ? {} : {disabled: 'disabled'};
     },

--- a/imports/ui/pages/org/page.html
+++ b/imports/ui/pages/org/page.html
@@ -54,7 +54,9 @@
                             Api Key
                         </label>
                         <div class="col-sm-10">
-                            <input class="form-control keyDisplay" id="org_api_key" type="text" value="{{org.apiKey}}" readonly />
+                            {{#each orgKey in org.orgKeys}}
+                                <input class="form-control keyDisplay" id="org_api_key" type="text" value="{{orgKey}}" readonly />
+                            {{/each}}
                         </div>
                     </div>
 
@@ -64,9 +66,9 @@
                         </label>
                         <div class="col-sm-10">
                             <div class="input-group">
-                                <code class="form-control text-truncate" id="org_command">kubectl create -f {{inventoryYamlUrl org.apiKey}}</code>
+                                <code class="form-control text-truncate" id="org_command">kubectl create -f {{inventoryYamlUrl (firstOrgKey org)}}</code>
                                 <div class="input-group-append">
-                                    <button class="btn btn-primary copy-button" type="button" data-clipboard-text="kubectl create -f {{inventoryYamlUrl org.apiKey}}">Copy</button>
+                                    <button class="btn btn-primary copy-button" type="button" data-clipboard-text="kubectl create -f {{inventoryYamlUrl (firstOrgKey org)}}">Copy</button>
                                 </div>
                             </div>
                         </div>
@@ -78,9 +80,9 @@
                         </label>
                         <div class="col-sm-10">
                             <div class="input-group mb-3">
-                                <code class="form-control text-truncate" id="org_command">kubectl create -f {{kapitanYamlUrl org.apiKey}}</code>
+                                <code class="form-control text-truncate" id="org_command">kubectl create -f {{kapitanYamlUrl (firstOrgKey org)}}</code>
                                 <div class="input-group-append">
-                                    <button class="btn btn-primary copy-button" type="button" data-clipboard-text="kubectl create -f {{kapitanYamlUrl org.apiKey}}">Copy</button>
+                                    <button class="btn btn-primary copy-button" type="button" data-clipboard-text="kubectl create -f {{kapitanYamlUrl (firstOrgKey org)}}">Copy</button>
                                 </div>
                             </div>
                         </div>


### PR DESCRIPTION
Depends on https://github.com/razee-io/Razeedash/pull/10

Users will need to run this command to migrate:
```
db.getCollection('orgs').find({}).forEach((org)=>{
    print(org.apiKey)
    db.orgs.updateOne({ _id: org._id }, { $set: { orgKeys: [org.apiKey] } });
})
```