### PR TITLE
only show counters when an orgName has been set

### DIFF
--- a/imports/ui/layouts/body/body.js
+++ b/imports/ui/layouts/body/body.js
@@ -82,6 +82,9 @@ Template.nav.helpers({
             return true;
         }
     },
+    showCounters() {
+        return Session.get('currentOrgName') ? true : false;
+    },
     clusterCount: () => (_.get(Stats.findOne({org_id:Session.get('currentOrgId')}), 'clusterCount') || 0).toLocaleString(),
     deploymentCount: () => (_.get(Stats.findOne({org_id:Session.get('currentOrgId')}), 'deploymentCount') || 0).toLocaleString()
 });

--- a/imports/ui/layouts/body/nav.html
+++ b/imports/ui/layouts/body/nav.html
@@ -36,6 +36,7 @@
         {{#if hasOrgsDefined }}
             {{#if showNavItems}}
                 {{> nav_org_dropdown}}
+                {{#if showCounters}}
                 <li class="nav-item {{isActive 'clusters.search'}}">
                     <a class="nav-link align-middle" href="{{pathFor 'clusters.search' query=(navItemQueryStr 'clusters')}}">
                         <span class="align-middle">Clusters</span>
@@ -49,6 +50,7 @@
                         <span class="badge badge-dark align-middle">{{deploymentCount}}</span>
                     </a>
                 </li>
+                {{/if}}
             {{/if}}
         {{/if}}
       </ul>


### PR DESCRIPTION
otherwise the Clusters and Resources links will point to an invalid route.   

The problem can be reproduced by:
-  login in to https://app.razee.io
- click a launch button for your org
- go to the Profile page
- reload your browser
- now the Clusters and Resources links are broken