### PR TITLE
show loading spinners for plotly charts

### DIFF
--- a/imports/ui/components/activeDeployments/component.html
+++ b/imports/ui/components/activeDeployments/component.html
@@ -17,6 +17,13 @@
 <template name="activeDeployments">
   <div class="card">
     {{> portletHeader title='Active deployments'}}
-    <div id="plotlychart" class="card-body p-1"></div>
+    {{#if chartIsLoading}}
+        {{> loading}}
+    {{/if}}
+    <div id="plotlychart" class="card-body p-1">
+        {{#if noData}}
+            <div class="m-3">No active deployments were found in Razee</div>
+        {{/if}}
+    </div>
   </div>
 </template>

--- a/imports/ui/components/activeDeployments/index.js
+++ b/imports/ui/components/activeDeployments/index.js
@@ -16,15 +16,31 @@
 
 import './component.html';
 import { Meteor } from 'meteor/meteor';
+import { ReactiveVar } from 'meteor/reactive-var';
 import { Template } from 'meteor/templating';
 import { FlowRouter } from 'meteor/kadira:flow-router';
 import Plotly from 'plotly.js-dist';
 import '../../components/portlet';
 import { Session } from 'meteor/session';
 
+let dataIsLoaded = new ReactiveVar(false);
+let noDataFound = new ReactiveVar(false);
+
+Template.activeDeployments.helpers({
+    chartIsLoading: () => {
+        const isFinished = dataIsLoaded.get();
+        return isFinished ? false : true;
+    },
+    noData: () => {
+        return noDataFound.get() ? true : false;
+    },
+}); 
+
 Template.activeDeployments.onRendered(function() {
     this.autorun(()=>{
+        dataIsLoaded.set(false);
         Meteor.call('getActiveDepsPerService', Session.get('currentOrgId'), (error, data) => {
+            dataIsLoaded.set(true);
             if (data){
                 const y = data.map(d => d.id.name);
                 const x = data.map(d => d.count);
@@ -83,7 +99,14 @@ Template.activeDeployments.onRendered(function() {
                         pad: 0,
                     },
                 };
-                const modeBarButtons = [[ 'toImage' ]];
+                let modeBarButtons = [[ 'toImage' ]];
+                if(data.length === 0) {
+                    noDataFound.set(true);
+                    layout.height = 50;
+                    layout.xaxis = null;
+                    layout.yaxis = null;
+                    modeBarButtons = null;
+                } 
                 Plotly.newPlot('plotlychart', plotdata, layout, {responsive: true, modeBarButtons: modeBarButtons, displaylogo: false });
                 document.getElementById('plotlychart').on('plotly_click', function(selected_data){
                     const orgName = FlowRouter.getParam('baseOrgName');

--- a/imports/ui/components/activeDeployments/index.js
+++ b/imports/ui/components/activeDeployments/index.js
@@ -102,18 +102,15 @@ Template.activeDeployments.onRendered(function() {
                 let modeBarButtons = [[ 'toImage' ]];
                 if(data.length === 0) {
                     noDataFound.set(true);
-                    layout.height = 50;
-                    layout.xaxis = null;
-                    layout.yaxis = null;
-                    modeBarButtons = null;
-                } 
-                Plotly.newPlot('plotlychart', plotdata, layout, {responsive: true, modeBarButtons: modeBarButtons, displaylogo: false });
-                document.getElementById('plotlychart').on('plotly_click', function(selected_data){
-                    const orgName = FlowRouter.getParam('baseOrgName');
-                    const params = { baseOrgName: orgName };
-                    const queryParams = { q: selected_data.points[0].y };
-                    FlowRouter.go('resources.search', params, queryParams);
-                });
+                }  else {
+                    Plotly.newPlot('plotlychart', plotdata, layout, {responsive: true, modeBarButtons: modeBarButtons, displaylogo: false });
+                    document.getElementById('plotlychart').on('plotly_click', function(selected_data){
+                        const orgName = FlowRouter.getParam('baseOrgName');
+                        const params = { baseOrgName: orgName };
+                        const queryParams = { q: selected_data.points[0].y };
+                        FlowRouter.go('resources.search', params, queryParams);
+                    });
+                }
             }
         });
     });

--- a/imports/ui/components/clustersByKubeVersion/component.html
+++ b/imports/ui/components/clustersByKubeVersion/component.html
@@ -18,7 +18,14 @@
   <div class="card">
     {{> portletHeader title=title}}
     <div class="card-body p-1">
-      <div id="clustersByKubeVersionChart"></div>
+        {{#if chartIsLoading}}
+            {{> loading}}
+        {{/if}}
+        <div id="clustersByKubeVersionChart">
+            {{#if noData}}
+                <div class="m-3">No active clusters are reporting to Razee</div>
+            {{/if}}
+        </div>
     </div>
   </div>
 </template>

--- a/imports/ui/components/clustersByKubeVersion/index.js
+++ b/imports/ui/components/clustersByKubeVersion/index.js
@@ -68,8 +68,6 @@ Template.clustersByKubeVersion.onRendered(function() {
             dataIsLoaded.set(true);
             if(data.length === 0) {
                 noDataFound.set(true);
-                layout.height = 50;
-                modeBarButtons = null;
             }
             
             data = data.map( d => {
@@ -102,19 +100,22 @@ Template.clustersByKubeVersion.onRendered(function() {
                     labels: y,
                     textinfo: 'value',
                 }];
-                Plotly.newPlot('clustersByKubeVersionChart', initalPlotData, layout, {responsive: true, modeBarButtons: modeBarButtons, displaylogo: false });
-                Plotly.animate('clustersByKubeVersionChart',
-                    {
-                        data: plotdata
-                    }, {
-                        transition: {
-                            duration: 500,
-                            easing: 'cubic-in-out'
-                        },
-                        frame: {
-                            duration: 500
-                        }
-                    });
+                if(data.length > 0) {
+                    Plotly.newPlot('clustersByKubeVersionChart', initalPlotData, layout, {responsive: true, modeBarButtons: modeBarButtons, displaylogo: false });
+                    Plotly.animate('clustersByKubeVersionChart',
+                        {
+                            data: plotdata
+                        }, {
+                            transition: {
+                                duration: 500,
+                                easing: 'cubic-in-out'
+                            },
+                            frame: {
+                                duration: 500
+                            }
+                        });
+
+                }
             } 
         });
     });

--- a/imports/ui/components/sevenDayDeployments/component.html
+++ b/imports/ui/components/sevenDayDeployments/component.html
@@ -39,6 +39,8 @@
           {{/each}}
         </tbody>
       </table>
+      {{else}}
+        {{> loading}}
       {{/if}}
     </div>
   </div>

--- a/imports/ui/components/updaterMessages/component.html
+++ b/imports/ui/components/updaterMessages/component.html
@@ -28,7 +28,7 @@
       <p class="text-muted font-14"><i class="fa fa-clock-o" aria-hidden="true"></i> {{moment message.updated}}</p>
     </div>
   {{else}}
-    <div class="pl-3">No recent updater messages.</div>
+    <div class="m-3">No recent updater messages</div>
   {{/each}}
 </template>
 


### PR DESCRIPTION
Also show better empty screens for when there is no data to display for the Active clusters by version and Active deployments charts


![image](https://user-images.githubusercontent.com/1749799/58263210-98229a80-7d49-11e9-931d-165af2645622.png)

![image](https://user-images.githubusercontent.com/1749799/58264225-7fb37f80-7d4b-11e9-9066-82b35b23730a.png)

