### PR TITLE
fix infinite spinner

### DIFF
--- a/imports/ui/components/clustersByKubeVersion/component.html
+++ b/imports/ui/components/clustersByKubeVersion/component.html
@@ -17,6 +17,7 @@
 <template name="clustersByKubeVersion">
   <div class="card">
     {{> portletHeader title=title}}
+    {{#if Template.subscriptionsReady}}
     <div class="card-body p-1">
         {{#if chartIsLoading}}
             {{> loading}}
@@ -27,5 +28,8 @@
             {{/if}}
         </div>
     </div>
+    {{else}}
+        {{> loading}}
+    {{/if}}
   </div>
 </template>

--- a/imports/ui/components/inactiveClusters/component.html
+++ b/imports/ui/components/inactiveClusters/component.html
@@ -18,6 +18,7 @@
   <div class="card">
     {{> portletHeader title='Inactive clusters' }}
     {{#if Template.subscriptionsReady}}
+      {{#if hasZombieClusters}}
         <table class="table table-sm table-responsive-sm">
           <thead>
             <tr>
@@ -31,11 +32,12 @@
               <td><a href="{{pathFor 'cluster.tab' id=cluster.cluster_id tabId='resources'}}">{{getClusterName cluster}}</a></td>
               <td>{{moment cluster.updated}}</td>
             </tr>
-            {{else}}
-            <span class="pl-3">Looks like your clusters are all current</span>
             {{/each}}
           </tbody>
         </table>
+      {{else}}
+            <span class="m-3">Looks like your clusters are all current</span>
+      {{/if}}
     {{else}}
       {{> loading}} 
     {{/if}}

--- a/imports/ui/components/inactiveClusters/index.js
+++ b/imports/ui/components/inactiveClusters/index.js
@@ -23,6 +23,10 @@ import { Session } from 'meteor/session';
 
 Template.inactiveClusters.helpers({
     zombieClusters: () => Clusters.find({ updated: { $lt: new moment().subtract(1, 'day').toDate() } }, { sort: { updated: -1 } }),
+    hasZombieClusters: () => {
+        const zombies = Clusters.find({ updated: { $lt: new moment().subtract(1, 'day').toDate() } }, { sort: { updated: -1 } }).count();
+        return (zombies > 0) ? true : false; 
+    },
 });
 
 Template.inactiveClusters.onCreated(function() {

--- a/imports/ui/components/recentDeployments/component.html
+++ b/imports/ui/components/recentDeployments/component.html
@@ -18,6 +18,7 @@
   <div class="card">
     {{> portletHeader title='Recent deployments' }}
     {{#if Template.subscriptionsReady}}
+      {{#if hasRecentDeployments}}
         <table class="table table-sm table-responsive-sm">
           <thead>
             <tr>
@@ -29,11 +30,12 @@
           <tbody>
             {{#each deployment in recentDeployments}}
                 {{> recentDeployments_row deployment=deployment}}
-            {{else}}
-            <span class="pl-3">There are no recent deployments</span>
             {{/each}}
           </tbody>
         </table>
+      {{else}}
+            <span class="m-3">There are no recent deployments</span>
+      {{/if}}
     {{else}}
       {{> loading}} 
     {{/if}}

--- a/imports/ui/components/recentDeployments/index.js
+++ b/imports/ui/components/recentDeployments/index.js
@@ -23,6 +23,10 @@ import { Session } from 'meteor/session';
 
 Template.recentDeployments.helpers({
     recentDeployments: () => Resources.find({}, { sort: { 'updated': -1 }, limit: 10 }),
+    hasRecentDeployments: () => {
+        const deploymentCount = Resources.find({}, { sort: { 'updated': -1 }, limit: 10 }).count();
+        return (deploymentCount > 0) ? true: false;
+    }
 });
 
 Template.recentDeployments.onCreated(function() {

--- a/imports/ui/components/sevenDayDeployments/component.html
+++ b/imports/ui/components/sevenDayDeployments/component.html
@@ -17,7 +17,8 @@
 <template name="sevenDayDeployments">
   <div class="card">
     {{> portletHeader title='Deployments over the past 7 days' }}
-    <div class="card-body p-0">
+    {{#if Template.subscriptionsReady}}
+    <div class="card-body p-3">
       {{#if recentDepsPerService}}
       <table class="table table-sm">
         <thead>
@@ -40,8 +41,11 @@
         </tbody>
       </table>
       {{else}}
-        {{> loading}}
+        <span>There are no deployments within the last 7 days</span>
       {{/if}}
     </div>
+    {{else}}
+        {{> loading}}
+    {{/if}}
   </div>
 </template>

--- a/imports/ui/layouts/body/nav.html
+++ b/imports/ui/layouts/body/nav.html
@@ -80,7 +80,7 @@
 <template name="nav_org_dropdown">
   <li class="nav-item dropdown">
     <a class="nav-link dropdown-toggle" href="#" data-toggle="dropdown">
-      <img class="org-image" src="{{iconForOrgName selectedOrgName}}" alt="" role="presentation" />
+      <img class="org-image mr-1" src="{{iconForOrgName selectedOrgName}}" alt="" role="presentation" />
       {{selectedOrgName}}
     </a>
     <div class="dropdown-menu dropdown-menu-right">


### PR DESCRIPTION
- don't show table headers when there is no data
- add more space between the org icon and the org name in the nav

fixes #54 