### PR TITLE
add a metadata table to the cluster details tab

### DIFF
--- a/imports/ui/components/cluster/details/component.html
+++ b/imports/ui/components/cluster/details/component.html
@@ -28,7 +28,7 @@
         </div>
       </div>
     </div>
-    <div class="m-3">
+    <div class="mt-3">
         {{> cluster_metadata cluster=cluster}}
     </div>
 </template>

--- a/imports/ui/components/cluster/details/component.html
+++ b/imports/ui/components/cluster/details/component.html
@@ -28,4 +28,27 @@
         </div>
       </div>
     </div>
+    <div class="m-3">
+        {{> cluster_metadata cluster=cluster}}
+    </div>
+</template>
+
+<template name="cluster_metadata">
+    {{#if metadata}}
+        <table class="table table-striped table-sm">
+            <thead>
+                <tr>
+                    <th colspan="2">Cluster metadata</th>
+                </tr>
+            </thead>
+            <tbody>
+            {{#each item in metadata}}
+                <tr>
+                    <td>{{item.name}}</td>
+                    <td>{{item.value}}</td>
+                </tr>
+            {{/each}}
+            </tbody>
+        </table>
+    {{/if}}
 </template>

--- a/imports/ui/components/cluster/details/index.js
+++ b/imports/ui/components/cluster/details/index.js
@@ -14,4 +14,22 @@
 * limitations under the License.
 */
 
+import { Template } from 'meteor/templating';
 import './component.html';
+
+Template.cluster_metadata.helpers({
+    metadata: () => {
+        const instance = Template.instance();
+        const cluster = instance.data.cluster;
+        if(!cluster || !cluster.metadata) {
+            return;
+        }
+        const metadata = [];
+        for(let key in cluster.metadata) {
+            if(typeof cluster.metadata[key] !== 'object') {
+                metadata.push({name: key, value: cluster.metadata[key] });
+            }
+        }
+        return metadata;
+    },
+});


### PR DESCRIPTION
implements #35 

if there is user defined metadata inside a clusters collection then display this data as a table on the Details tab of an individual cluster page

<img width="1054" alt="image" src="https://user-images.githubusercontent.com/1749799/58649810-1992a380-82db-11e9-8bcb-c0e445944163.png">
