### PR TITLE
prevent the pie chart from collapsing

### DIFF
--- a/imports/ui/components/activeDeployments/index.js
+++ b/imports/ui/components/activeDeployments/index.js
@@ -103,7 +103,7 @@ Template.activeDeployments.onRendered(function() {
                 if(data.length === 0) {
                     noDataFound.set(true);
                 }  else {
-                    Plotly.newPlot('plotlychart', plotdata, layout, {responsive: true, modeBarButtons: modeBarButtons, displaylogo: false });
+                    Plotly.newPlot('plotlychart', plotdata, layout, {modeBarButtons: modeBarButtons, displaylogo: false });
                     document.getElementById('plotlychart').on('plotly_click', function(selected_data){
                         const orgName = FlowRouter.getParam('baseOrgName');
                         const params = { baseOrgName: orgName };

--- a/imports/ui/components/clustersByKubeVersion/index.js
+++ b/imports/ui/components/clustersByKubeVersion/index.js
@@ -28,6 +28,7 @@ let noDataFound = new ReactiveVar(false);
 
 Template.clustersByKubeVersion.onCreated( () => {
     dataIsLoaded.set(false);
+    noDataFound.set(false);
     Template.instance().title = new ReactiveVar( 'Active clusters by version' );
 });
 


### PR DESCRIPTION
also fix a problem where the Active Deployments chart would get collapsed when changing the size of the browser window.

fixes #53 