### PR TITLE
requires the user has access when loading 'clusters.id' subscription

### DIFF
--- a/imports/api/cluster/clusters/server/publications.js
+++ b/imports/api/cluster/clusters/server/publications.js
@@ -41,9 +41,11 @@ Meteor.publish('clusters.zombie', function(orgId) {
     });
 });
 
-Meteor.publish('clusters.id', function(clusterId) {
+Meteor.publish('clusters.id', function(orgId, clusterId) {
+    check( orgId, String );
     check( clusterId, String );
-    return Clusters.find({ cluster_id: clusterId });
+    requireOrgAccess(orgId);
+    return Clusters.find({ org_id: orgId, cluster_id: clusterId });
 });
 
 Meteor.publish('clusterSearch', function(orgId, searchStr, limit=50) {

--- a/imports/ui/components/breadcrumbs/index.js
+++ b/imports/ui/components/breadcrumbs/index.js
@@ -32,7 +32,7 @@ Template.breadcrumbs.onCreated(function(){
             if(_.includes(['cluster'], crumb.routeName)){
                 // if theres a crumb to go to a single cluster page, then subscribes so it can find() it
                 var id = crumb.params.id || crumb.params.clusterId;
-                this.subscribe('clusters.id', id);
+                this.subscribe('clusters.id', Session.get('currentOrgId'), id);
             }
         });
         setTitleToLastCrumb(breadcrumbs);

--- a/imports/ui/components/recentDeployments/index.js
+++ b/imports/ui/components/recentDeployments/index.js
@@ -33,6 +33,6 @@ Template.recentDeployments.onCreated(function() {
 
 Template.recentDeployments_row.onCreated(function() {
     this.autorun(() => {
-        this.subscribe('clusters.id', this.data.deployment.cluster_id);
+        this.subscribe('clusters.id', Session.get('currentOrgId'), this.data.deployment.cluster_id);
     });
 });

--- a/imports/ui/pages/clusters/index.js
+++ b/imports/ui/pages/clusters/index.js
@@ -161,7 +161,7 @@ Template.page_clusters.events({
 
 Template.page_cluster_id.onCreated(function() {
     this.autorun(() => {
-        this.subscribe('clusters.id', FlowRouter.getParam('id'));
+        this.subscribe('clusters.id', Session.get('currentOrgId'), FlowRouter.getParam('id'));
     });
 });
 

--- a/imports/ui/pages/clusters/page.html
+++ b/imports/ui/pages/clusters/page.html
@@ -96,15 +96,17 @@
 </template>
 
 <template name="page_cluster_id">
-  <div class="m-2">
-    {{#if Template.subscriptionsReady}} 
-        {{#if getCluster}} 
-            {{>cluster cluster=getCluster notCollapsable=1}} 
-        {{else}} 
-            Cluster not found 
-        {{/if}} 
-    {{else}} 
-        {{> loading }} 
-    {{/if}}
-  </div>
+  {{#if orgIdFound }}
+    <div class="m-2">
+      {{#if Template.subscriptionsReady}}
+          {{#if getCluster}}
+              {{>cluster cluster=getCluster notCollapsable=1}}
+          {{else}}
+              Cluster not found
+          {{/if}}
+      {{else}}
+          {{> loading }}
+      {{/if}}
+    </div>
+  {{/if}}
 </template>

--- a/imports/ui/pages/resources/index.js
+++ b/imports/ui/pages/resources/index.js
@@ -299,14 +299,14 @@ Template.page_resources_resource.helpers({
 
 Template.page_resources_resource.onCreated(function() {
     this.autorun(() => {
-        this.subscribe('clusters.id', this.data.resource.cluster_id);
+        this.subscribe('clusters.id', Session.get('currentOrgId'), this.data.resource.cluster_id);
     });
 });
 
 Template.page_resource_id.onCreated(function() {
     this.autorun(() => {
         var clusterId = FlowRouter.getParam('id');
-        this.subscribe('clusters.id', clusterId);
+        this.subscribe('clusters.id', Session.get('currentOrgId'), clusterId);
     });
 });
 

--- a/imports/ui/pages/resources/resourcesSingle.jsx
+++ b/imports/ui/pages/resources/resourcesSingle.jsx
@@ -7,6 +7,7 @@ import Blaze from 'meteor/gadicc:blaze-react-component';
 import moment from 'moment';
 import resourceKinds from './resourceKindComponents';
 import { FlowRouter } from 'meteor/kadira:flow-router';
+import { Session } from "meteor/session";
 
 export class ResourcesSingle extends React.Component {
     render() {
@@ -107,7 +108,7 @@ export default withTracker(()=>{
     var orgId = Session.get('currentOrgId');
     var subs = [
         Meteor.subscribe('resources.bySelfLink', orgId, clusterId, selfLink),
-        Meteor.subscribe('clusters.id', clusterId),
+        Meteor.subscribe('clusters.id', Session.get('currentOrgId'), clusterId),
         Meteor.subscribe('resourceData.bySelfLink', orgId, clusterId, selfLink),
     ];
     var resource = Resources.findOne({


### PR DESCRIPTION
Mainly just updated 'clusters.id' sub to have `(orgId, clusterId)` as args instead of just `(clusterId)`