### PR TITLE
only show email if it exists

### DIFF
--- a/imports/ui/pages/userprofile/page.html
+++ b/imports/ui/pages/userprofile/page.html
@@ -33,12 +33,15 @@
                                 readonly>
                             <small id="emailHelp" class="form-text text-muted">This comes from GitHub and cannot be updated.</small>
                         </div>
+
+                        {{#if currentUser.services.github.email}}
                         <div class="form-group">
                             <label for="inputEmail">Email address</label>
-                            <input type="email" class="form-control" id="inputEmail" aria-describedby="emailHelp" placeholder="Enter email" value="{{currentUser.services.github.email}}"
+                            <input type="email" class="form-control" id="inputEmail" aria-describedby="emailHelp" placeholder="email" value="{{currentUser.services.github.email}}"
                                 readonly>
                             <small id="emailHelp" class="form-text text-muted">This comes from GitHub and cannot be updated.</small>
                         </div>
+                        {{/if}}
 
                         <div class="form-group">
                             <label for="inputUserid">User ID</label>


### PR DESCRIPTION
a users email address will only show up in the collection if they set their github profile to have their email publically displayed.  So only show email field in the UI if it exists