### PR TITLE
added btn for triggering a watchkeeper refresh

### DIFF
--- a/imports/api/cluster/clusters/methods.js
+++ b/imports/api/cluster/clusters/methods.js
@@ -71,4 +71,18 @@ Meteor.methods({
         });
         return out;
     },
+    requestClusterResync(orgId, clusterId){
+        check( orgId, String );
+        check( clusterId, String );
+        requireOrgAccess(orgId);
+
+        var search = {
+            org_id: orgId,
+            cluster_id: clusterId,
+        };
+        var sets = {
+            dirty: true,
+        };
+        Clusters.update(search, { $set: sets });
+    }
 });

--- a/imports/ui/components/cluster/details/component.html
+++ b/imports/ui/components/cluster/details/component.html
@@ -15,22 +15,43 @@
 -->
 
 <template name="cluster_info">
-    <div class="m-0">
-      <div class="clusterInfo no-gutters row border-bottom text-center align-middle text-center p-2 m-0">
-        <div class="col-6 col-lg-3 m-0 px-0">
-            <span class="fieldValue">{{moment cluster.created}}</span><br />
-            <small class="m-0 text-muted">Created</small>
+    {{#if orgIdFound}}
+        <div class="m-0 p-0">
+            <div class="clusterInfo no-gutters row text-center text-center m-0 p-0 align-items-stretch">
+
+                <div class="col-12 col-lg-4 m-0 py-2 border-bottom">
+                    <span class="fieldValue">{{moment cluster.created}}</span><br />
+                    <small class="m-0 text-muted">Created</small>
+                </div>
+                <div class="col-12 col-lg-4 m-0 py-2 border-bottom">
+                    <div>
+                        <span class="fieldValue">{{moment cluster.updated}}</span><br />
+                        <small class="m-0 text-muted">Last refreshed</small>
+
+                        <div>
+                            {{#if cluster.dirty}}
+                                <div class="text-muted border-top pt-2 mt-2">Refresh requested...</div>
+                            {{else}}
+                                <button class="btn btn-primary" id="requestClusterResync">Request Refresh</button>
+                            {{/if}}
+                        </div>
+                    </div>
+                </div>
+                <div class="col-12 col-lg-4 m-0 py-2 border-bottom">
+                    <div>
+                        {{gitVersion cluster}}
+                    </div>
+                    <div class="small text-muted">
+                        Kube version
+                    </div>
+                </div>
+            </div>
         </div>
 
-        <div class="col-6 col-lg-3 m-0 px-0">
-            <span class="fieldValue">{{moment cluster.updated}}</span><br />
-            <small class="m-0 text-muted">Last refreshed</small>
+        <div class="mt-3">
+            {{> cluster_metadata cluster=cluster}}
         </div>
-      </div>
-    </div>
-    <div class="mt-3">
-        {{> cluster_metadata cluster=cluster}}
-    </div>
+    {{/if}}
 </template>
 
 <template name="cluster_metadata">

--- a/imports/ui/components/cluster/details/index.js
+++ b/imports/ui/components/cluster/details/index.js
@@ -14,8 +14,12 @@
 * limitations under the License.
 */
 
+import { Meteor } from 'meteor/meteor';
+import { Session } from 'meteor/session';
 import { Template } from 'meteor/templating';
 import './component.html';
+import _ from 'lodash';
+import { FlowRouter } from 'meteor/kadira:flow-router';
 
 Template.cluster_metadata.helpers({
     metadata: () => {
@@ -31,5 +35,24 @@ Template.cluster_metadata.helpers({
             }
         }
         return metadata;
+    },
+});
+
+Template.cluster_info.helpers({
+    clusterId(){
+        return FlowRouter.getParam('id');
+    },
+    gitVersion(cluster){
+        return _.get(cluster, 'metadata.kube_version.gitVersion');
+    }
+});
+Template.cluster_info.events({
+    'click #requestClusterResync'(){
+        var clusterId = Template.cluster_info.__helpers.get('clusterId').call(Template.instance());
+        Meteor.call('requestClusterResync', Session.get('currentOrgId'), clusterId, (err)=>{
+            if(err){
+                throw err;
+            }
+        });
     },
 });


### PR DESCRIPTION
Hitting the button puts the cluster in a `.dirty` state so watchkeeper knows to do a refresh on its next poll. After clicking the button and before watchkeeper does the refresh, the user will see "Refresh requested..."

Also put the kube version on the page because thats some cluster data we have that we werent displaying.

![image](https://user-images.githubusercontent.com/20116801/59297675-cadbf680-8c56-11e9-9efd-a5643b4591dd.png)


![image](https://user-images.githubusercontent.com/20116801/59297668-c31c5200-8c56-11e9-82da-afa20a051da1.png)
