### PR TITLE
add a trailing slash to razeedash_api_url if needed

### DIFF
--- a/imports/startup/client/index.js
+++ b/imports/startup/client/index.js
@@ -46,7 +46,11 @@ export let hasOrgsDefined = new ReactiveVar(true);
 Template.registerHelper('clusterYamlUrl', (key) => {
     let url = Meteor.absoluteUrl(`api/install/cluster?orgKey=${key}`);
     if(Meteor.settings.public.RAZEEDASH_API_URL){
-        url = `${Meteor.settings.public.RAZEEDASH_API_URL}api/install/cluster?orgKey=${key}`;
+        let apiUrl = Meteor.settings.public.RAZEEDASH_API_URL;
+        if(apiUrl.substr(-1) !== '/') {
+            apiUrl += '/';
+        }
+        url = `${apiUrl}api/install/cluster?orgKey=${key}`;
     }
     return url;
 });


### PR DESCRIPTION
This will help ensure that the `Install Razee Agent` link we provide is accurate even if the user does not add a trailing slash to their `RAZEEDASH_API_URL` config map variable. 

For example, we now will display 
`kubectl create -f "http://localhost:3333/api/install/cluster?orgKey=orgApiKey...` instead of
`kubectl create -f "http://localhost:3333api/install/cluster?orgKey=orgApiKey...`


re: https://github.com/razee-io/Razee/issues/31