### PR TITLE
Add prune feature to address #97

### DIFF
--- a/imports/api/cluster/clusters/methods.js
+++ b/imports/api/cluster/clusters/methods.js
@@ -84,5 +84,12 @@ Meteor.methods({
             dirty: true,
         };
         Clusters.update(search, { $set: sets });
+    },
+    pruneCluster(orgId, clusterId){
+        check(orgId, String);
+        check(clusterId, String);
+        requireOrgAccess(orgId);
+
+        Clusters.remove({ cluster_id: clusterId });
     }
 });

--- a/imports/api/resource/methods.js
+++ b/imports/api/resource/methods.js
@@ -74,5 +74,11 @@ Meteor.methods({
             return item;
         });
         return out;
+    },
+    pruneClusterResources(orgId, clusterId){
+        check(orgId, String)
+        check(clusterId, String);
+        requireOrgAccess(orgId);
+        Resources.remove({ cluster_id: clusterId});
     }
 });

--- a/imports/ui/components/inactiveClusters/component.html
+++ b/imports/ui/components/inactiveClusters/component.html
@@ -25,6 +25,7 @@
             <tr>
               <th>Cluster</th>
               <th>Last active</th>
+              <th>Action</th>
             </tr>
           </thead>
           <tbody>
@@ -32,6 +33,7 @@
             <tr>
               <td><a href="{{pathFor 'cluster.tab' id=cluster.cluster_id tabId='resources'}}">{{getClusterName cluster}}</a></td>
               <td>{{moment cluster.updated}}</td>
+              <td><button class="delete" cluster_id="{{cluster.cluster_id}}">Remove</button></td>
             </tr>
             {{/each}}
           </tbody>

--- a/imports/ui/components/inactiveClusters/index.js
+++ b/imports/ui/components/inactiveClusters/index.js
@@ -17,9 +17,11 @@
 import './component.html';
 import { Template } from 'meteor/templating';
 import { Clusters } from '/imports/api/cluster/clusters/clusters';
+import { Resources } from '/imports/api/resource/resources';
 import '../../components/portlet';
 import moment from 'moment';
 import { Session } from 'meteor/session';
+import { Meteor } from 'meteor/meteor';
 
 Template.inactiveClusters.helpers({
     zombieClusters: () => Clusters.find({ updated: { $lt: new moment().subtract(1, 'day').toDate() } }, { sort: { updated: -1 } }),
@@ -34,3 +36,22 @@ Template.inactiveClusters.onCreated(function() {
         this.subscribe('clusters.zombie', Session.get('currentOrgId'));
     });
 });
+
+Template.inactiveClusters.events({
+    'click .delete'(event){
+        var confirmation = confirm("Are you sure?")
+        if (confirmation){
+            Meteor.call("pruneCluster", Session.get('currentOrgId'), event.target.attributes['cluster_id'].value, (err) => {
+                if (err){
+                    throw err;
+                }
+            });
+            Meteor.call("pruneClusterResources", Session.get('currentOrgId'), event.target.attributes['cluster_id'].value, (err) => {
+                if (err) {
+                    throw err;
+                }
+            });
+        }
+    }
+        
+})


### PR DESCRIPTION
This PR adds a `Remove` button to the *Inactive Clusters* widget in the dashboard. Clicking on this button for the cluster will remove all records of it from the Clusters and Resources Mongo collections thus removing it from the dashboard (purging). This PR can address #97 