### PR TITLE
searchable attr management

### DIFF
--- a/imports/api/org/methods.js
+++ b/imports/api/org/methods.js
@@ -141,7 +141,7 @@ Meteor.methods({
     },
     saveCustomSearchableAttrsObj(orgId, data){
 
-console.log(`todo: remove this`);
+        console.log('todo: remove this');
 
         requireOrgAccess(orgId);
         var search = {

--- a/imports/api/org/methods.js
+++ b/imports/api/org/methods.js
@@ -139,19 +139,6 @@ Meteor.methods({
         }
         return true;
     },
-    saveCustomSearchableAttrsObj(orgId, data){
-
-        console.log('todo: remove this');
-
-        requireOrgAccess(orgId);
-        var search = {
-            _id: orgId,
-        };
-        var sets = {
-            'customSearchableAttrs': data,
-        };
-        Orgs.update(search, { $set: sets });
-    },
     addCustomSearchableAttrKind(orgId, kind){
         check(orgId, String);
         check(kind, String);

--- a/imports/api/org/methods.js
+++ b/imports/api/org/methods.js
@@ -65,7 +65,6 @@ Meteor.methods({
         });
 
         if(org){
-            console.log(`org "${name}" already exists`);
             throw new Meteor.Error(`org "${name}" already exists`);
         }
 
@@ -125,7 +124,6 @@ Meteor.methods({
                     ]
                 });
             } else {
-                console.log(`org "${name}" was not found`);
                 throw new Meteor.Error(`org "${name}" was not found.`);
             }
         } else {

--- a/imports/api/org/methods.js
+++ b/imports/api/org/methods.js
@@ -140,6 +140,9 @@ Meteor.methods({
         return true;
     },
     saveCustomSearchableAttrsObj(orgId, data){
+
+console.log(`todo: remove this`);
+
         requireOrgAccess(orgId);
         var search = {
             _id: orgId,
@@ -149,4 +152,62 @@ Meteor.methods({
         };
         Orgs.update(search, { $set: sets });
     },
+    addCustomSearchableAttrKind(orgId, kind){
+        check(orgId, String);
+        check(kind, String);
+        requireOrgAccess(orgId);
+        var search = {
+            _id: orgId,
+            [`customSearchableAttrs.${kind}`]: { $exists: false },
+        };
+        var sets = {
+            [`customSearchableAttrs.${kind}`]: [],
+        };
+        Orgs.update(search, { $set: sets });
+    },
+    deleteCustomSearchableAttrKind(orgId, kind){
+        check(orgId, String);
+        check(kind, String);
+        requireOrgAccess(orgId);
+        var search = {
+            _id: orgId,
+        };
+        Orgs.update(search, { $unset: { [`customSearchableAttrs.${kind}`]: true } });
+    },
+    setCustomSearchableAttrKindIdx(orgId, kind, idx, val){
+        check(orgId, String);
+        check(kind, String);
+        check(idx, Number);
+        check(val, String);
+        requireOrgAccess(orgId);
+        var search = {
+            _id: orgId,
+        };
+        var updateObj = {
+            $set: {
+                [`customSearchableAttrs.${kind}.${idx}`]: val,
+            },
+        };
+        if(idx == -1){
+            updateObj = {
+                $push: {
+                    [`customSearchableAttrs.${kind}`]: val,
+                },
+            };
+        }
+        Orgs.update(search, updateObj);
+    },
+    deleteCustomSearchableAttrKindIdx(orgId, kind, idx){
+        check(orgId, String);
+        check(kind, String);
+        check(idx, Number);
+        var search = {
+            _id: orgId,
+        };
+        // apparently mongo doesnt let you remove an array item by index, so what we'll do is set the item to null and then remove all nulls
+        // sets the item to null
+        Orgs.update(search, { $unset: { [`customSearchableAttrs.${kind}.${idx}`]: true } });
+        // removes all nulls
+        Orgs.update(search, { $pull: { [`customSearchableAttrs.${kind}`]: null } });
+    }
 });

--- a/imports/api/org/methods.js
+++ b/imports/api/org/methods.js
@@ -20,6 +20,7 @@ import { Meteor } from 'meteor/meteor';
 import uuid from 'uuid';
 import { Orgs } from './orgs.js';
 import ghe from '../lib/ghe.js';
+import { requireOrgAccess } from '/imports/api/org/utils.js';
 
 Meteor.methods({
     hasOrgs() {
@@ -83,5 +84,15 @@ Meteor.methods({
         }
         Orgs.remove({ name: name });
         return true;
+    },
+    saveCustomSearchableAttrsObj(orgId, data){
+        requireOrgAccess(orgId);
+        var search = {
+            _id: orgId,
+        };
+        var sets = {
+            'customSearchableAttrs': data,
+        };
+        Orgs.update(search, { $set: sets });
     },
 });

--- a/imports/api/org/server/publications.js
+++ b/imports/api/org/server/publications.js
@@ -20,7 +20,7 @@ import { Meteor } from 'meteor/meteor';
 import { Orgs } from '../orgs.js';
 
 Meteor.publish('orgIdByName', function(orgName){
-    return Orgs.find({ name: orgName }, { _id: 1, name: 1});
+    return Orgs.find({ name: orgName }, { _id: 1, name: 1, customSearchableAttrs: 1});
 });
 
 Meteor.publish('orgs', function(names){
@@ -34,7 +34,7 @@ Meteor.publish('orgsForUser', function(){
         return;
     }
     var orgNames = _.map(Meteor.user().github.orgs || [], 'name');
-    return Orgs.find({ name: { $in: orgNames } }, { name: 1, orgYaml: 1 });
+    return Orgs.find({ name: { $in: orgNames } }, { name: 1, orgYaml: 1, customSearchableAttrs:1 });
 });
 
 Meteor.publish('gheOrg', (orgName)=>{

--- a/imports/api/resource/methods.js
+++ b/imports/api/resource/methods.js
@@ -74,5 +74,12 @@ Meteor.methods({
             return item;
         });
         return out;
-    }
+    },
+    async getResourceKindsForOrg(orgId){
+        requireOrgAccess(orgId);
+        var out = await Resources.rawCollection().distinct('searchableData.kind');
+        out = _.filter(out);
+        out = _.sortBy(out);
+        return out;
+    },
 });

--- a/imports/ui/pages/org/index.js
+++ b/imports/ui/pages/org/index.js
@@ -168,10 +168,40 @@ Template.OrgManageSearchableAttrs.events({
         }
         customSearchableAttrsObj.set(obj);
     },
+    'keyup .newAttrPathItem'(e){
+        var $el = $(e.currentTarget);
+        var $container = $el.closest('.attrPathContainer');
+        var kind = $container.attr('kind');
+        var val = $el.val();
+
+        if(!val){
+            return;
+        }
+
+        var obj = customSearchableAttrsObj.get();
+        obj[kind].push(val);
+        $el.val('');
+        customSearchableAttrsObj.set(obj);
+
+        _.debounce(()=>{
+            $el.closest('.card-body').find('.attrPathItem:not(.newAttrPathItem)').eq(-1).focus();
+        })();
+    },
     'click .saveBtn'(){
         var attrObj = customSearchableAttrsObj.get();
         Meteor.call('saveCustomSearchableAttrsObj', Session.get('currentOrgId'), attrObj, ()=>{
         });
+    },
+    'click .deleteKindGroupBtn'(e){
+        var $el = $(e.currentTarget);
+        var $container = $el.closest('.kindContainer');
+        var kind = $container.attr('kind');
+
+        var obj = customSearchableAttrsObj.get();
+        delete obj[kind];
+        customSearchableAttrsObj.set(obj);
+
+        return false;
     },
 });
 

--- a/imports/ui/pages/org/index.js
+++ b/imports/ui/pages/org/index.js
@@ -84,9 +84,9 @@ Template.OrgManageSearchableAttrs.onCreated(function(){
         Orgs.findOne({ name: orgName, });
         var inst = Template.instance();
         _.defer(()=>{
-            updateChangesTracker(inst)
+            updateChangesTracker(inst);
         });
-    })
+    });
 });
 Template.OrgManageSearchableAttrs.helpers({
     loadedKinds(){
@@ -160,7 +160,7 @@ var updateChangesTracker = (templateInstance)=>{
 };
 
 Template.OrgManageSearchableAttrs.events({
-    'keyup .attrPathItem'(e){
+    'keyup .attrPathItem'(){
         // updates the changesTracker
         updateChangesTracker(Template.instance());
     },
@@ -168,7 +168,7 @@ Template.OrgManageSearchableAttrs.events({
         var $el = $(e.currentTarget);
         var $kind = $el.closest('.input-group').find('.trackKindDropdown');
         var kind = $kind.val();
-        Meteor.call('addCustomSearchableAttrKind', Session.get('currentOrgId'), kind, (err, data)=>{
+        Meteor.call('addCustomSearchableAttrKind', Session.get('currentOrgId'), kind, ()=>{
         });
     },
     'click .removeAttrPathBtn'(e){
@@ -183,7 +183,7 @@ Template.OrgManageSearchableAttrs.events({
         }
 
         $el.prop('disabled', true);
-        Meteor.call('deleteCustomSearchableAttrKindIdx', Session.get('currentOrgId'), kind, idx, (err, data)=>{
+        Meteor.call('deleteCustomSearchableAttrKindIdx', Session.get('currentOrgId'), kind, idx, ()=>{
         });
     },
     'click .saveAttrPathBtn'(e){
@@ -198,7 +198,7 @@ Template.OrgManageSearchableAttrs.events({
             return;
         }
 
-        Meteor.call('setCustomSearchableAttrKindIdx', Session.get('currentOrgId'), kind, idx, val, (err, data)=>{
+        Meteor.call('setCustomSearchableAttrKindIdx', Session.get('currentOrgId'), kind, idx, val, ()=>{
             if(idx == -1){
                 $container.find('.attrPathItem').val('');
             }
@@ -218,7 +218,7 @@ Template.OrgManageSearchableAttrs.events({
 
         $modal.modal('hide');
 
-        Meteor.call('deleteCustomSearchableAttrKind', Session.get('currentOrgId'), kind, (err, data)=>{
+        Meteor.call('deleteCustomSearchableAttrKind', Session.get('currentOrgId'), kind, ()=>{
         });
 
         return false;

--- a/imports/ui/pages/org/index.js
+++ b/imports/ui/pages/org/index.js
@@ -96,6 +96,15 @@ Template.OrgManageSearchableAttrs.helpers({
     availableKinds(){
         return availableKinds.get();
     },
+    unusedKinds(){
+        var availableKinds = Template.OrgManageSearchableAttrs.__helpers.get('availableKinds').call(Template.instance());
+        var usedKinds = Template.OrgManageSearchableAttrs.__helpers.get('usedKinds').call(Template.instance());
+        return _.without(availableKinds, ...usedKinds);
+    },
+    isTrackBtnDisabled(){
+        var unusedKinds = Template.OrgManageSearchableAttrs.__helpers.get('unusedKinds').call(Template.instance());
+        return (unusedKinds.length < 1 ? 'disabled' : '');
+    },
     usedKinds(){
         return _.keys(customSearchableAttrsObj.get());
     },

--- a/imports/ui/pages/org/index.js
+++ b/imports/ui/pages/org/index.js
@@ -22,6 +22,8 @@ import { Template } from 'meteor/templating';
 import { Orgs } from '/imports/api/org/orgs';
 import Clipboard from 'clipboard';
 import _ from 'lodash';
+import { Session } from 'meteor/session';
+import { ReactiveVar } from 'meteor/reactive-var';
 
 Template.OrgSingle.onCreated( () => {
     const template = Template.instance();
@@ -56,3 +58,121 @@ Template.OrgSingle.helpers({
         return Orgs.findOne({ name: Template.instance().orgName });
     },
 });
+
+
+var availableKinds = new ReactiveVar([]);
+var loadedKinds = new ReactiveVar(false);
+var customSearchableAttrsObj = new ReactiveVar(null);
+var hasChanges = new ReactiveVar(false);
+
+Template.OrgManageSearchableAttrs.onCreated(function(){
+    this.autorun(()=>{
+        var instance = Template.instance();
+        loadedKinds.set(false);
+        Meteor.call('getResourceKindsForOrg', Session.get('currentOrgId'), (err, data)=>{
+            loadedKinds.set(true);
+            availableKinds.set(data);
+            hasChanges.set(false);
+            var customSearchableAttrs = _.cloneDeep(_.get(instance, 'data.org.customSearchableAttrs', {}));
+            customSearchableAttrsObj.set(customSearchableAttrs);
+        });
+    });
+    this.autorun(()=>{
+        // updates hasChanges
+        var originalCustomSearchableAttrs = Template.currentData().org.customSearchableAttrs;
+        hasChanges.set(!_.isEqual(originalCustomSearchableAttrs, customSearchableAttrsObj.get()));
+    });
+});
+Template.OrgManageSearchableAttrs.helpers({
+    hasChanges(){
+        return hasChanges.get();
+    },
+    loadedKinds(){
+        return loadedKinds.get();
+    },
+    org(){
+        return Template.instance().data.org;
+    },
+    availableKinds(){
+        return availableKinds.get();
+    },
+    usedKinds(){
+        return _.keys(customSearchableAttrsObj.get());
+    },
+    kindIsUsed(kind){
+        var usedKinds = Template.OrgManageSearchableAttrs.__helpers.get('usedKinds').call(Template.instance());
+        return _.includes(usedKinds, kind);
+    },
+    hasAnyUsedKinds(){
+        var usedKinds = Template.OrgManageSearchableAttrs.__helpers.get('usedKinds').call(Template.instance());
+        return (usedKinds.length > 0);
+    },
+    saveBtnDisabledAttr(){
+        var hasChanges = Template.OrgManageSearchableAttrs.__helpers.get('hasChanges').call(Template.instance());
+        return (hasChanges ? '' : 'disabled');
+    },
+    attrsUsedForKind(kind){
+        return _.get(customSearchableAttrsObj.get(), `['${kind}']`, []);
+    },
+    exampleAttrPaths(){
+        return [
+            'metadata.name',
+            'metadata.namespace',
+            'spec.template.spec.containers[0].image',
+            'metadata.annotations["deployment.kubernetes.io/revision"]',
+        ];
+    },
+});
+
+Template.OrgManageSearchableAttrs.events({
+    'click .trackBtn'(e){
+        var $el = $(e.currentTarget);
+        var $kind = $el.closest('.input-group').find('.trackKindDropdown');
+        var kind = $kind.val();
+        var obj = customSearchableAttrsObj.get();
+        obj[kind] = obj[kind] || [];
+        customSearchableAttrsObj.set(obj);
+    },
+    'click .removeAttrPathBtn'(e){
+        var $el = $(e.currentTarget);
+        var $container = $el.closest('.attrPathContainer');
+        var kind = $container.attr('kind');
+        var idx = $container.attr('idx');
+        idx = (idx == 'new' ? -1 :  parseInt(idx));
+
+        if(idx == -1){
+            $el.val('');
+            return;
+        }
+
+        var obj = customSearchableAttrsObj.get();
+        obj[kind].splice(idx, 1);
+        customSearchableAttrsObj.set(obj);
+    },
+    'change .attrPathItem'(e){
+        var $el = $(e.currentTarget);
+        var $container = $el.closest('.attrPathContainer');
+        var val = $el.val();
+        var kind = $container.attr('kind');
+        var idx = $container.attr('idx');
+        idx = (idx == 'new' ? -1 :  parseInt(idx));
+
+        var obj = customSearchableAttrsObj.get();
+
+        if(idx == -1){ //new attr
+            obj[kind].push(val);
+            $el.val('');
+        }
+        else{
+            obj[kind][idx] = val;
+        }
+        customSearchableAttrsObj.set(obj);
+    },
+    'click .saveBtn'(e){
+        var attrObj = customSearchableAttrsObj.get();
+        Meteor.call('saveCustomSearchableAttrsObj', Session.get('currentOrgId'), attrObj, (err, data)=>{
+        });
+    },
+});
+
+

--- a/imports/ui/pages/org/index.js
+++ b/imports/ui/pages/org/index.js
@@ -168,9 +168,9 @@ Template.OrgManageSearchableAttrs.events({
         }
         customSearchableAttrsObj.set(obj);
     },
-    'click .saveBtn'(e){
+    'click .saveBtn'(){
         var attrObj = customSearchableAttrsObj.get();
-        Meteor.call('saveCustomSearchableAttrsObj', Session.get('currentOrgId'), attrObj, (err, data)=>{
+        Meteor.call('saveCustomSearchableAttrsObj', Session.get('currentOrgId'), attrObj, ()=>{
         });
     },
 });

--- a/imports/ui/pages/org/page.html
+++ b/imports/ui/pages/org/page.html
@@ -134,9 +134,12 @@
                                 </div>
                             </div>
                             {{#each kind in usedKinds}}
-                                <div class="col-12 col-md-6 col-xl-4 mb-2">
+                                <div class="col-12 col-md-6 col-xl-4 mb-2 kindContainer" kind="{{kind}}">
                                     <div class="card">
-                                        <h5 class="card-header text-muted">"{{kind}}" attributes</h5>
+                                        <h5 class="card-header text-muted position-relative">
+                                            <span>"{{kind}}" attributes</span>
+                                            <button class="btn btn-danger position-absolute deleteKindGroupBtn" style="right:10px;top:5px;">X</button>
+                                        </h5>
                                         <div class="card-body mb-0">
                                             {{#each attrPath in (attrsUsedForKind kind)}}
                                                 <div class="input-group mb-2 attrPathContainer" kind="{{kind}}" idx="{{@index}}">
@@ -147,7 +150,7 @@
                                                 </div>
                                             {{/each}}
                                             <div class="input-group mb-2 attrPathContainer" kind="{{kind}}" idx="new">
-                                                <input type="text" value="" class="form-control attrPathItem"/>
+                                                <input type="text" value="" class="form-control attrPathItem newAttrPathItem"/>
                                                 <div class="input-group-append">
                                                     <button class="btn btn-danger">X</button>
                                                 </div>

--- a/imports/ui/pages/org/page.html
+++ b/imports/ui/pages/org/page.html
@@ -137,22 +137,36 @@
                                         <h5 class="card-header text-muted position-relative">
                                             <span>"{{kind}}" attributes</span>
                                             <button class="btn btn-danger position-absolute deleteKindGroupBtn" style="right:10px;top:5px;">X</button>
+
+                                            <div class="modal deleteModal" tabindex="-1" role="dialog">
+                                                <div class="modal-dialog" role="document">
+                                                    <div class="modal-content">
+                                                        <div class="modal-header">
+                                                            <h5 class="modal-title">Delete attributes for "{{kind}}"</h5>
+                                                            <button type="button" class="close" data-dismiss="modal" aria-label="Close">
+                                                                <span aria-hidden="true">&times;</span>
+                                                            </button>
+                                                        </div>
+                                                        <div class="modal-body">
+                                                            <p>Are you sure you want to delete the RazeeDash custom searchable attributes for kubernetes kind <strong>"{{kind}}"</strong>?</p>
+                                                        </div>
+                                                        <div class="modal-footer">
+                                                            <button type="button" class="btn btn-link" data-dismiss="modal">Cancel</button>
+                                                            <button type="button" class="btn btn-primary deleteKindGroupConfirmBtn">Delete</button>
+                                                        </div>
+                                                    </div>
+                                                </div>
+                                            </div>
                                         </h5>
                                         <div class="card-body mb-0">
                                             {{#each attrPath in (attrsUsedForKind kind)}}
                                                 <div class="input-group mb-2 attrPathContainer" kind="{{kind}}" idx="{{@index}}">
                                                     <input type="text" value="{{attrPath}}" class="form-control attrPathItem"/>
-                                                    {{#if attrPathIdxHasChanges kind @index}}
-                                                        <div class="input-group-append">
-                                                            {{#if canSaveIdx kind @index}}
-                                                                <button class="btn btn-primary saveAttrPathBtn" {{kindIdxSaveIsDisabled kind @index}}>Save</button>
-                                                            {{else}}
-                                                                <div class="text-success align-self-center px-2">
-                                                                    <i class="fa fa-check" aria-hidden="true"></i>
-                                                                </div>
-                                                            {{/if}}
-                                                        </div>
-                                                    {{/if}}
+                                                    <div class="input-group-append">
+                                                        {{#if canSaveIdx kind @index}}
+                                                            <button class="btn btn-primary saveAttrPathBtn">Save</button>
+                                                        {{/if}}
+                                                    </div>
                                                     <div class="input-group-append">
                                                         <button class="btn btn-danger removeAttrPathBtn">X</button>
                                                     </div>
@@ -160,11 +174,9 @@
                                             {{/each}}
                                             <div class="input-group mb-2 attrPathContainer" kind="{{kind}}" idx="-1">
                                                 <input type="text" value="" class="form-control attrPathItem newAttrPathItem"/>
-                                                {{#if attrPathIdxHasChanges kind -1}}
-                                                    <div class="input-group-append">
-                                                        <button class="btn btn-primary saveAttrPathBtn">Save</button>
-                                                    </div>
-                                                {{/if}}
+                                                <div class="input-group-append">
+                                                    <button class="btn btn-primary saveAttrPathBtn">Save</button>
+                                                </div>
                                                 <div class="input-group-append">
                                                     <button class="btn btn-danger removeAttrPathBtn">X</button>
                                                 </div>

--- a/imports/ui/pages/org/page.html
+++ b/imports/ui/pages/org/page.html
@@ -89,27 +89,31 @@
         <div class="card-body">
             {{#if loadedKinds}}
                 <div class="mb-3">
-                    Select a kubernetes "kind" to track attribute history for:
-                    <div class="input-group">
+                    <div class="d-flex justify-content-between">
                         <div>
-                            <select class="form-control trackKindDropdown" style="width:200px;">
-                                {{#each kind in availableKinds}}
-                                    {{#if kindIsUsed kind}}
-                                        <option disabled value="{{kind}}">{{kind}} (already tracking)</option>
-                                    {{else}}
-                                        <option value="{{kind}}">{{kind}}</option>
-                                    {{/if}}
-                                {{/each}}
-                            </select>
+                            Select a kubernetes "kind" to track attribute history for:
+                            <div class="input-group">
+                                <div>
+                                    <select class="form-control trackKindDropdown" style="width:200px;">
+                                        {{#each kind in availableKinds}}
+                                            {{#if kindIsUsed kind}}
+                                                <option disabled value="{{kind}}">{{kind}} (already tracking)</option>
+                                            {{else}}
+                                                <option value="{{kind}}">{{kind}}</option>
+                                            {{/if}}
+                                        {{/each}}
+                                    </select>
+                                </div>
+                                <div class="input-group-append">
+                                    <button class="btn btn-primary trackBtn" {{isTrackBtnDisabled}}>Track</button>
+                                </div>
+                            </div>
                         </div>
-                        <div class="input-group-append">
-                            <button class="btn btn-primary trackBtn" {{isTrackBtnDisabled}}>Track</button>
+                        <div>
+                            <br />
+                            <button class="btn btn-primary saveBtn" {{saveBtnDisabledAttr}}>Save Changes</button>
                         </div>
                     </div>
-                </div>
-
-                <div class="d-flex justify-content-end">
-                    <button class="btn btn-primary saveBtn" {{saveBtnDisabledAttr}}>Save Changes</button>
                 </div>
 
                 {{#if hasAnyUsedKinds}}

--- a/imports/ui/pages/org/page.html
+++ b/imports/ui/pages/org/page.html
@@ -103,17 +103,17 @@
                             </select>
                         </div>
                         <div class="input-group-append">
-                            <button class="btn btn-primary trackBtn">Track</button>
+                            <button class="btn btn-primary trackBtn" {{isTrackBtnDisabled}}>Track</button>
                         </div>
                     </div>
                 </div>
 
+                <div class="d-flex justify-content-end">
+                    <button class="btn btn-primary saveBtn" {{saveBtnDisabledAttr}}>Save Changes</button>
+                </div>
+
                 {{#if hasAnyUsedKinds}}
                     <div>
-                        <div class="d-flex justify-content-end">
-                            <button class="btn btn-primary saveBtn" {{saveBtnDisabledAttr}}>Save Changes</button>
-                        </div>
-
                         <div class="row">
                             <div class="col-12 col-md-6 col-xl-4 mb-2">
                                 <div class="card">

--- a/imports/ui/pages/org/page.html
+++ b/imports/ui/pages/org/page.html
@@ -77,5 +77,96 @@
                 </form>
             </div>
         </div>
+
+        {{> OrgManageSearchableAttrs org=org }}
+
     {{/if}}
+</template>
+
+<template name="OrgManageSearchableAttrs">
+    <div class="card m-2">
+        <h4 class="card-header text-muted">Custom Searchable Attributes</h4>
+        <div class="card-body">
+            {{#if loadedKinds}}
+                <div class="mb-3">
+                    Select a kubernetes "kind" to track attribute history for:
+                    <div class="input-group">
+                        <div>
+                            <select class="form-control trackKindDropdown" style="width:200px;">
+                                {{#each kind in availableKinds}}
+                                    {{#if kindIsUsed kind}}
+                                        <option disabled value="{{kind}}">{{kind}} (already tracking)</option>
+                                    {{else}}
+                                        <option value="{{kind}}">{{kind}}</option>
+                                    {{/if}}
+                                {{/each}}
+                            </select>
+                        </div>
+                        <div class="input-group-append">
+                            <button class="btn btn-primary trackBtn">Track</button>
+                        </div>
+                    </div>
+                </div>
+
+                {{#if hasAnyUsedKinds}}
+                    <div>
+                        <div class="d-flex justify-content-end">
+                            <button class="btn btn-primary saveBtn" {{saveBtnDisabledAttr}}>Save Changes</button>
+                        </div>
+
+                        <div class="row">
+                            <div class="col-12 col-md-6 col-xl-4 mb-2">
+                                <div class="card">
+                                    <h5 class="card-header text-muted">Example attributes</h5>
+                                    <div class="card-body">
+                                        <div class="text-muted mb-3">
+                                            Pass the javascript object path of the resource yaml attributes you want to track:
+                                        </div>
+                                        {{#each attrPath in exampleAttrPaths}}
+                                            <div class="input-group mb-2">
+                                                <input class="form-control" type="text" disabled value="{{attrPath}}"/>
+                                            </div>
+                                        {{/each}}
+                                        <div class="text-muted mt-3">
+                                            Tracks the name, namespace, first container image, and kube revision number (of, for instance, a deployment object).
+                                        </div>
+                                    </div>
+                                </div>
+                            </div>
+                            {{#each kind in usedKinds}}
+                                <div class="col-12 col-md-6 col-xl-4 mb-2">
+                                    <div class="card">
+                                        <h5 class="card-header text-muted">"{{kind}}" attributes</h5>
+                                        <div class="card-body mb-0">
+                                            {{#each attrPath in (attrsUsedForKind kind)}}
+                                                <div class="input-group mb-2 attrPathContainer" kind="{{kind}}" idx="{{@index}}">
+                                                    <input type="text" value="{{attrPath}}" class="form-control attrPathItem"/>
+                                                    <div class="input-group-append">
+                                                        <button class="btn btn-danger removeAttrPathBtn">X</button>
+                                                    </div>
+                                                </div>
+                                            {{/each}}
+                                            <div class="input-group mb-2 attrPathContainer" kind="{{kind}}" idx="new">
+                                                <input type="text" value="" class="form-control attrPathItem"/>
+                                                <div class="input-group-append">
+                                                    <button class="btn btn-danger">X</button>
+                                                </div>
+                                            </div>
+                                        </div>
+                                    </div>
+                                </div>
+                            {{/each}}
+                        </div>
+
+                        <div class="d-flex justify-content-end">
+                            <button class="btn btn-primary saveBtn" {{saveBtnDisabledAttr}}>Save Changes</button>
+                        </div>
+
+                    </div>
+                {{/if}}
+            {{else}}
+                {{> loading text='Loading resource kind list' }}
+            {{/if}}
+        </div>
+    </div>
 </template>

--- a/imports/ui/pages/org/page.html
+++ b/imports/ui/pages/org/page.html
@@ -78,7 +78,7 @@
             </div>
         </div>
 
-        {{> OrgManageSearchableAttrs org=org }}
+        {{> OrgManageSearchableAttrs org=org orgName=orgName}}
 
     {{/if}}
 </template>
@@ -89,29 +89,23 @@
         <div class="card-body">
             {{#if loadedKinds}}
                 <div class="mb-3">
-                    <div class="d-flex justify-content-between">
-                        <div>
-                            Select a kubernetes "kind" to track attribute history for:
-                            <div class="input-group">
-                                <div>
-                                    <select class="form-control trackKindDropdown" style="width:200px;">
-                                        {{#each kind in availableKinds}}
-                                            {{#if kindIsUsed kind}}
-                                                <option disabled value="{{kind}}">{{kind}} (already tracking)</option>
-                                            {{else}}
-                                                <option value="{{kind}}">{{kind}}</option>
-                                            {{/if}}
-                                        {{/each}}
-                                    </select>
-                                </div>
-                                <div class="input-group-append">
-                                    <button class="btn btn-primary trackBtn" {{isTrackBtnDisabled}}>Track</button>
-                                </div>
+                    <div>
+                        Select a kubernetes "kind" to track attribute history for:
+                        <div class="input-group">
+                            <div>
+                                <select class="form-control trackKindDropdown" style="width:200px;">
+                                    {{#each kind in availableKinds}}
+                                        {{#if kindIsUsed kind}}
+                                            <option disabled value="{{kind}}">{{kind}} (already tracking)</option>
+                                        {{else}}
+                                            <option value="{{kind}}">{{kind}}</option>
+                                        {{/if}}
+                                    {{/each}}
+                                </select>
                             </div>
-                        </div>
-                        <div>
-                            <br />
-                            <button class="btn btn-primary saveBtn" {{saveBtnDisabledAttr}}>Save Changes</button>
+                            <div class="input-group-append">
+                                <button class="btn btn-primary trackBtn" {{isTrackBtnDisabled}}>Track</button>
+                            </div>
                         </div>
                     </div>
                 </div>
@@ -148,15 +142,31 @@
                                             {{#each attrPath in (attrsUsedForKind kind)}}
                                                 <div class="input-group mb-2 attrPathContainer" kind="{{kind}}" idx="{{@index}}">
                                                     <input type="text" value="{{attrPath}}" class="form-control attrPathItem"/>
+                                                    {{#if attrPathIdxHasChanges kind @index}}
+                                                        <div class="input-group-append">
+                                                            {{#if canSaveIdx kind @index}}
+                                                                <button class="btn btn-primary saveAttrPathBtn" {{kindIdxSaveIsDisabled kind @index}}>Save</button>
+                                                            {{else}}
+                                                                <div class="text-success align-self-center px-2">
+                                                                    <i class="fa fa-check" aria-hidden="true"></i>
+                                                                </div>
+                                                            {{/if}}
+                                                        </div>
+                                                    {{/if}}
                                                     <div class="input-group-append">
                                                         <button class="btn btn-danger removeAttrPathBtn">X</button>
                                                     </div>
                                                 </div>
                                             {{/each}}
-                                            <div class="input-group mb-2 attrPathContainer" kind="{{kind}}" idx="new">
+                                            <div class="input-group mb-2 attrPathContainer" kind="{{kind}}" idx="-1">
                                                 <input type="text" value="" class="form-control attrPathItem newAttrPathItem"/>
+                                                {{#if attrPathIdxHasChanges kind -1}}
+                                                    <div class="input-group-append">
+                                                        <button class="btn btn-primary saveAttrPathBtn">Save</button>
+                                                    </div>
+                                                {{/if}}
                                                 <div class="input-group-append">
-                                                    <button class="btn btn-danger">X</button>
+                                                    <button class="btn btn-danger removeAttrPathBtn">X</button>
                                                 </div>
                                             </div>
                                         </div>
@@ -164,11 +174,6 @@
                                 </div>
                             {{/each}}
                         </div>
-
-                        <div class="d-flex justify-content-end">
-                            <button class="btn btn-primary saveBtn" {{saveBtnDisabledAttr}}>Save Changes</button>
-                        </div>
-
                     </div>
                 {{/if}}
             {{else}}

--- a/imports/ui/pages/resources/resourcesSingle.jsx
+++ b/imports/ui/pages/resources/resourcesSingle.jsx
@@ -69,7 +69,7 @@ class ResourceKindAttrTable extends React.Component{
     render(){
         var attrNames = _.filter(_.keys(this.props.resource.searchableData), (item) => { 
             // the annotations keys won't look good when displayed in the table so we remove them here
-            return item.indexOf('annotations_') !== 0
+            return item.indexOf('annotations[') !== 0
         });
         var rows = _.map(attrNames, (attrName)=>{
             var val = this.props.resource.searchableData[attrName];


### PR DESCRIPTION
Adds this ui to the manage org page
![image](https://user-images.githubusercontent.com/20116801/60922040-e17f6880-a269-11e9-8bc9-ceaac0b1b819.png)

And saves them in `customSearchableAttrs` of the org:
![image](https://user-images.githubusercontent.com/20116801/60922098-fcea7380-a269-11e9-9c31-eacb1d675ded.png)
, where the key is the kube "kind". and the value is an array of the attr paths we want to track
