### PR TITLE
use node:8-alpine instead of mhart/alpine-node:8

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM mhart/alpine-node:8
+FROM node:8-alpine 
 
 LABEL maintainer="Michael McKay <mckaymic@us.ibm.com>"
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:8-alpine 
+FROM node:8-alpine
 
 LABEL maintainer="Michael McKay <mckaymic@us.ibm.com>"
 


### PR DESCRIPTION
fixes core dump when using login_type:local