### PR TITLE
creating a new route to give us a better breadcrumb structure

### DIFF
--- a/imports/startup/client/routes.js
+++ b/imports/startup/client/routes.js
@@ -131,6 +131,15 @@ orgedRoutes.route('/resources/:clusterId', {
     },
 });
 
+orgedRoutes.route('/clusters/:clusterId/resources/resource', {
+    name: 'cluster.resource',
+    title: 'Resource Cluster :clusterId',
+    parent: 'cluster.tab',
+    action(params, queryParams) {
+        BlazeLayout.render('Base_layout', { main: 'Resources_single', selfLink: queryParams.selfLink, clusterId: params.clusterId });
+    },
+});
+
 FlowRouter.notFound = {
     action() {
         BlazeLayout.render('Base_layout', { main: 'App_notFound', doesntRequireOrgIdLoaded: true });

--- a/imports/ui/components/breadcrumbs/index.js
+++ b/imports/ui/components/breadcrumbs/index.js
@@ -81,6 +81,14 @@ Template.breadcrumbs.helpers({
             }catch(e){} // eslint-disable-line no-empty
             return name;
         }
+        if(crumb.routeName === 'cluster.resource') {
+            let displayName = '';
+            try{
+                displayName = crumb.route._queryParams.get('selfLink');
+                displayName = _.last(_.filter(displayName.split('/')));
+            }catch(e){} // eslint-disable-line no-empty
+            return displayName;
+        }
         if(_.includes(['cluster.tab'], crumb.routeName)){
             // if a crumb for the single cluster page, then find()s it so we can display its name
             var id = crumb.params.id || crumb.params.clusterId;
@@ -100,6 +108,22 @@ Template.breadcrumbs.helpers({
             if(clustersSearch_q){
                 qs.q = clustersSearch_q;
             }
+        }
+        if(crumb.routeName == 'cluster.tab') {
+            const clusterId = FlowRouter.current().params.clusterId || FlowRouter.current().params.id;
+            const tabID = FlowRouter.current().params.tabId || 'resources';
+            const params = {
+                'id': clusterId,
+                'tabId': tabID
+            };
+            return FlowRouter.path(crumb.route.name, params);
+        }
+        if(crumb.routeName == 'cluster.resource') {
+            let displayLink = '';
+            try{
+                displayLink = crumb.route._queryParams.get('selfLink');
+            }catch(e){} // eslint-disable-line no-empty
+            qs.selfLink = displayLink;
         }
         if(crumb.routeName == 'resource.cluster'){
             var selfLink = '';

--- a/imports/ui/components/cluster/resources/component.html
+++ b/imports/ui/components/cluster/resources/component.html
@@ -49,7 +49,7 @@
           <i class="fa fa-ellipsis-v" aria-hidden="true"></i>
       </div>
       {{> kindIcon kind=resource.searchableData.kind}}
-       <a class="bx--link" href="{{pathFor 'resource.cluster' clusterId=cluster_id query=(resourceLinkQuery resource)}}">
+       <a class="bx--link" href="{{pathFor 'cluster.resource' clusterId=cluster_id query=(resourceLinkQuery resource)}}">
         <span class="text-muted">{{resource.searchableData.namespace}}</span>/{{resource.searchableData.name}}
       </a>
       <div class="dropdown-menu dropdown-menu-right" aria-labelledby="dropdownMenuButton">


### PR DESCRIPTION
When clicking a resource name from the cluster -> resources tab, the new breadcrumbs will look like this:
![image](https://user-images.githubusercontent.com/1749799/62956665-58f06c80-bdc1-11e9-82d6-5e851fa3d26d.png)



instead of this:
![image](https://user-images.githubusercontent.com/1749799/62956641-4ece6e00-bdc1-11e9-98b2-1e549ef4b882.png)

fixes #125 