### PR TITLE
ensure the org link has a slash

### DIFF
--- a/imports/startup/client/index.js
+++ b/imports/startup/client/index.js
@@ -149,11 +149,13 @@ Template.registerHelper('bitbucketUrl', ()=>{
 });
 Template.registerHelper('scmUrl', ()=>{
     const service = getServiceConfiguration();
+    let scmLink = '';
     if(service === 'bitbucket') {
-        return Meteor.settings.public.BITBUCKET_URL;
+        scmLink = Meteor.settings.public.BITBUCKET_URL;
     } else {
-        return Meteor.settings.public.GITHUB_URL;
+        scmLink = Meteor.settings.public.GITHUB_URL;
     }
+    return scmLink.endsWith('/') ? scmLink : scmLink + '/';
 });
 
 Template.registerHelper('currentGheOrgName', ()=>{


### PR DESCRIPTION
this makes sure we don't end up with a url like `https://github.ibm.comopen-razee/` . 
 Instead this would make it `https://github.ibm.com/open-razee/`