### PR TITLE
Add securityContext to deployment

### DIFF
--- a/kubernetes/razeedash/resource.yaml
+++ b/kubernetes/razeedash/resource.yaml
@@ -30,6 +30,9 @@ items:
             app: razeedash
           name: razeedash
         spec:
+          securityContext:
+            fsGroup: 999
+            runAsUser: 999
           containers:
           - env:
             - name: MONGO_URL

--- a/kubernetes/razeedash/resource.yaml
+++ b/kubernetes/razeedash/resource.yaml
@@ -96,6 +96,7 @@ items:
             - name: app_name
               value: Razeedash
             image: "quay.io/razee/razeedash:{{TRAVIS_TAG}}"
+            workingDir: /app
             imagePullPolicy: Always
             name: razeedash
             ports:


### PR DESCRIPTION
Make sure we can run Razee Dashboard on a Kubernetes system
where we don't allow containers to execute as root user.