### PR TITLE
Use user `node` inside Docker images

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,6 +24,7 @@ RUN apk update \
 	&& apk del --purge ${BUILD_PACKAGES} \
     && $METEORD_DIR/clean-final.sh
 
+USER node
 EXPOSE 3000
 ENV BUILD_ID=${BUILD_ID}
 ENV LAST_COMMIT_ID=${LAST_COMMIT_ID}

--- a/kubernetes/razeedash/resource.yaml
+++ b/kubernetes/razeedash/resource.yaml
@@ -33,9 +33,6 @@ items:
             app: razeedash
           name: razeedash
         spec:
-          securityContext:
-            fsGroup: 999
-            runAsUser: 999
           containers:
           - env:
             - name: MONGO_URL


### PR DESCRIPTION
To avoid the problems caused by inclusion of the securityContext
in pull request #84 lets instead switch the user inside the docker
container to the node user already created inside the upstream
image. This way we run as UID != 0 and we don't hard code a UID
and GID that causes problems when running on Openshift clusters
where the 999 values where too low.

```
Warning   FailedCreate   replicaset/razeedash-dfc7b5fd5
Error creating: pods "razeedash-dfc7b5fd5-" is forbidden: unable to validate against
any security context constraint: [fsGroup: Invalid value: []int64{999}:
999 is not an allowed group spec.containers[0].securityContext.securityContext.runAsUser:
Invalid value: 999: must be in the ranges: [1000200000, 1000209999]]
```