### PR TITLE
update apiVersion

### DIFF
--- a/kubernetes/razeedash/resource.yaml
+++ b/kubernetes/razeedash/resource.yaml
@@ -8,7 +8,7 @@ metadata:
     razee.io/commit-sha: "{{TRAVIS_COMMIT}}"
 type: array
 items:
-  - apiVersion: extensions/v1beta1
+  - apiVersion: apps/v1
     kind: Deployment
     metadata:
       annotations:


### PR DESCRIPTION
https://github.com/razee-io/Razeedash/issues/197 -- Deployment API Version 'extensions/v1beta1' Not compatible with K8s 1.16

https://www.ibm.com/cloud/blog/announcements/kubernetes-version-1-16-removes-deprecated-apis

