### PR TITLE
don't show the noClusters template on some routes

### DIFF
--- a/imports/ui/components/noClusters/component.html
+++ b/imports/ui/components/noClusters/component.html
@@ -1,0 +1,27 @@
+<!-- 
+ Copyright 2019 IBM Corp. All Rights Reserved.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+-->
+
+<template name="noClusters">
+    <div class="card">
+        <div class="card-header cardHeader d-flex no-block">
+            <h5 class="text-muted my-0">No data</h5>
+        </div>
+        <div class="card-body p-1">
+            <div class="m-3">No clusters were found in Razee. Go to the <i class="fa fa-cog m-1 text-muted"></i> settings menu to add a cluster.
+            </div>
+        </div>
+    </div>
+</template>

--- a/imports/ui/components/noClusters/index.js
+++ b/imports/ui/components/noClusters/index.js
@@ -1,0 +1,17 @@
+/**
+* Copyright 2019 IBM Corp. All Rights Reserved.
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*      http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+import './component.html';

--- a/imports/ui/layouts/body/body.html
+++ b/imports/ui/layouts/body/body.html
@@ -21,19 +21,13 @@
                 {{#if currentUser}}
                     {{> nav}}
                         <div class="container-fluid px-0">
-                            {{> breadcrumbs }}
-                            {{#if hasRazeeData}}
-                              {{> Template.dynamic template=main}}
+                            {{#if skipClusterCheck}}
+                                {{> Template.dynamic template=main}}
+                            {{else if hasClusters}}
+                                {{> breadcrumbs }}
+                                {{> Template.dynamic template=main}}
                             {{else}}
-                                <div class="card">
-                                    <div class="card-header cardHeader d-flex no-block">
-                                        <h5 class="text-muted my-0">No data</h5>
-                                    </div>
-                                    <div class="card-body p-1">
-                                        <div class="m-3">No clusters were found in Razee. Go to the <i class="fa fa-cog m-1 text-muted"></i> settings menu to add a cluster.
-                                        </div>
-                                    </div>
-                                </div>
+                                {{> noClusters }} 
                             {{/if}}
                         </div>
                     {{> footer}}

--- a/imports/ui/layouts/body/body.js
+++ b/imports/ui/layouts/body/body.js
@@ -20,6 +20,7 @@ import './body.html';
 import './footer.html';
 import '../../pages/login';
 import '../../components/addCluster';
+import '../../components/noClusters';
 
 import { Meteor } from 'meteor/meteor';
 import { Session } from 'meteor/session';
@@ -49,8 +50,11 @@ Template.Base_layout.helpers({
 Template.Base_layout.onRendered(function() {
     this.autorun(()=>{
         this.subscribe('userData');
-        this.subscribe('clusters.org', Session.get('currentOrgId'));
         var orgName = Session.get('currentOrgName');
+        const orgId = Session.get('currentOrgId');
+        if(orgId) {
+            this.subscribe('clusters.org', orgId);
+        } 
         this.subscribe('orgIdByName', orgName);
         Meteor.call('hasOrgs', function(err, result) {
             hasOrgsDefined.set(result);
@@ -81,7 +85,16 @@ Template.Base_layout.helpers({
     currentOrgName(){
         return Session.get('currentOrgName');
     },
-    hasRazeeData () {
+    skipClusterCheck() {
+        // Don't show the 'noClusters' template on these routes
+        const route = currentRoute.get();
+        if(route === 'root' || route === 'org' || route === 'profile') {
+            return true;
+        } else {
+            return false;
+        }
+    },
+    hasClusters () {
         const clusters = Clusters.find({ org_id: Session.get('currentOrgId')}).count();
         return (clusters > 0) ? true : false;
     }


### PR DESCRIPTION
This fixes a bug where we would display the 'no clusters found' error message on pages like the welcome screen, org page and the profile page.  