### PR TITLE
Fix: use the localUser function in orgsForUser check

### DIFF
--- a/imports/api/org/server/publications.js
+++ b/imports/api/org/server/publications.js
@@ -18,6 +18,7 @@ import _ from 'lodash';
 import { check } from 'meteor/check';
 import { Meteor } from 'meteor/meteor';
 import { Orgs } from '../orgs.js';
+import { localUser } from '../../lib/login.js';
 
 Meteor.publish('orgIdByName', function(orgName){
     return Orgs.find({ name: orgName }, { _id: 1, name: 1, customSearchableAttrs: 1});
@@ -29,13 +30,13 @@ Meteor.publish('orgs', function(names){
 });
 
 Meteor.publish('orgsForUser', function(){
-    if(Meteor.user() && (Meteor.user().bitbucket || Meteor.user().github)) {
-        const orgNames = _.map(Meteor.user().orgs || [], 'name');
-        return Orgs.find({ name: { $in: orgNames } }, { name: 1, orgYaml: 1, customSearchableAttrs: 1 });
-    } else {
+    if(localUser()) {
         // local users should be able to see see all orgs with type local
         return Orgs.find({ type: 'local' }, { name: 1, customSearchableAttrs: 1 });
-    }
+    } else {
+        const orgNames = _.map(Meteor.user().orgs || [], 'name');
+        return Orgs.find({ name: { $in: orgNames } }, { name: 1, customSearchableAttrs: 1 });
+    } 
 });
 
 Meteor.publish('gheOrg', (orgName)=>{


### PR DESCRIPTION
- the orgsForUser publication was broken b/c it was looking at Meteor.user().bitbucket|github but those no longer exist. 
- also removing `orgYaml: 1` from the subscription as that doesn't seem to be used anywhere