### PR TITLE
remove ensureIndex

### DIFF
--- a/imports/api/cluster/clusters/clusters.js
+++ b/imports/api/cluster/clusters/clusters.js
@@ -15,7 +15,6 @@
 */
 
 import { Mongo } from 'meteor/mongo';
-import { Meteor } from 'meteor/meteor';
 
 export const Clusters = new Mongo.Collection('clusters');
 
@@ -24,7 +23,3 @@ Clusters.deny({
     update() { return true; },
     remove() { return true; },
 });
-
-if ( Meteor.isServer ) {
-    Clusters._ensureIndex({created:1});
-}

--- a/imports/api/deployables/channels/channels.js
+++ b/imports/api/deployables/channels/channels.js
@@ -15,7 +15,6 @@
 */
 
 import { Mongo } from 'meteor/mongo';
-import { Meteor } from 'meteor/meteor';
 
 export const Channels = new Mongo.Collection('channels');
 
@@ -24,7 +23,3 @@ Channels.deny({
     update() { return true; },
     remove() { return true; },
 });
-
-if ( Meteor.isServer ) {
-    Channels._ensureIndex( { 'org_id': 1 } );
-}

--- a/imports/api/deployables/channels/deployableVersions.js
+++ b/imports/api/deployables/channels/deployableVersions.js
@@ -15,7 +15,6 @@
 */
 
 import { Mongo } from 'meteor/mongo';
-import { Meteor } from 'meteor/meteor';
 
 export const DeployableVersions = new Mongo.Collection('deployableVersions');
 
@@ -24,7 +23,3 @@ DeployableVersions.deny({
     update() { return true; },
     remove() { return true; },
 });
-
-if ( Meteor.isServer ) {
-    DeployableVersions._ensureIndex( { 'org_id': 1} );
-}

--- a/imports/api/deployables/groups/groups.js
+++ b/imports/api/deployables/groups/groups.js
@@ -24,7 +24,3 @@ Groups.deny({
     update() { return true; },
     remove() { return true; },
 });
-
-// if ( Meteor.isServer ) {
-//     Groups._ensureIndex( { 'org_id': 1, 'name': 1 } );
-// }

--- a/imports/api/deployables/subscriptions/subscriptions.js
+++ b/imports/api/deployables/subscriptions/subscriptions.js
@@ -15,7 +15,6 @@
 */
 
 import { Mongo } from 'meteor/mongo';
-import { Meteor } from 'meteor/meteor';
 
 export const Subscriptions = new Mongo.Collection('subscriptions');
 
@@ -24,7 +23,3 @@ Subscriptions.deny({
     update() { return true; },
     remove() { return true; },
 });
-
-if ( Meteor.isServer ) {
-    Subscriptions._ensureIndex( { 'org_id': 1 } );
-}

--- a/imports/api/externalApplications/externalApplications.js
+++ b/imports/api/externalApplications/externalApplications.js
@@ -15,7 +15,6 @@
 */
 
 import { Mongo } from 'meteor/mongo';
-import { Meteor } from 'meteor/meteor';
 
 export const ExternalApplications = new Mongo.Collection('externalApplications');
 
@@ -24,7 +23,3 @@ ExternalApplications.deny({
     update() { return true; },
     remove() { return true; },
 });
-
-if ( Meteor.isServer ) {
-    ExternalApplications._ensureIndex( { 'org_id': 'text' } );
-}

--- a/imports/api/resource/resources.js
+++ b/imports/api/resource/resources.js
@@ -15,7 +15,6 @@
 */
 
 import { Mongo } from 'meteor/mongo';
-import { Meteor } from 'meteor/meteor';
 
 export const Resources = new Mongo.Collection('resources');
 
@@ -24,19 +23,3 @@ Resources.deny({
     update() { return true; },
     remove() { return true; },
 });
-
-try {
-    if ( Meteor.isServer ) {
-        Resources._ensureIndex( { 
-            'cluster_id': 'text', 
-            'cluster_name': 'text',
-            'searchableData.name': 'text', 
-            'searchableData.namespace': 'text', 
-            'searchableData.kind': 'text',
-            'selfLink': 'text'
-        },
-        {name: 'cluster_id_text_searchableData.name_text_searchableData.namespace_text' } );
-    }
-} catch (error) {
-    console.log(error);
-}

--- a/imports/api/resourceYamlHist/resourceYamlHist.js
+++ b/imports/api/resourceYamlHist/resourceYamlHist.js
@@ -15,7 +15,6 @@
  */
 
 import { Mongo } from 'meteor/mongo';
-import { Meteor } from 'meteor/meteor';
 
 export const ResourceYamlHist = new Mongo.Collection('resourceYamlHist');
 
@@ -24,7 +23,3 @@ ResourceYamlHist.deny({
     update() { return true; },
     remove() { return true; },
 });
-
-if ( Meteor.isServer ) {
-    ResourceYamlHist._ensureIndex( { org_id: 1, cluster_id: 1, resourceSelfLink: 1, updated: 1 } );
-}

--- a/imports/api/userLog/userLog.js
+++ b/imports/api/userLog/userLog.js
@@ -1,7 +1,6 @@
 // Colletion to hold all user log entries
 
 import { Mongo } from 'meteor/mongo';
-import { Meteor } from 'meteor/meteor';
 
 export const UserLog = new Mongo.Collection('user_log');
 
@@ -10,7 +9,3 @@ UserLog.deny({
     update() { return true; },
     remove() { return true; },
 });
-
-if ( Meteor.isServer ) {
-    UserLog._ensureIndex( { 'userid': 1, 'action': 1} );
-}


### PR DESCRIPTION
any new index should be created via the api instead.   this will prevent errors like 
```
razeedash MongoError: Index: { v: 2, key: { _fts: "text", _ftsx: 1 }, name: "cluster_id_text_searchableData.name_text_searchableData.namespace_text", weights: { cluster_id: 1, cluster_name: 1, searchableData.kind: 1, searchableData.na 
razeedash     at Connection.<anonymous> (/app/programs/server/npm/node_modules/meteor/npm-mongo/node_modules/mongodb/lib/core/connection/pool.js:450:61)                                                                                   
razeedash     at Connection.emit (events.js:315:20)                                                                                                                                                                                        
razeedash     at processMessage (/app/programs/server/npm/node_modules/meteor/npm-mongo/node_modules/mongodb/lib/core/connection/connection.js:384:10)                                                                                     
razeedash     at Socket.<anonymous> (/app/programs/server/npm/node_modules/meteor/npm-mongo/node_modules/mongodb/lib/core/connection/connection.js:553:15)                                                                                 
razeedash     at Socket.emit (events.js:315:20)                                                                                                                                                                                            
razeedash     at addChunk (_stream_readable.js:295:12)                                                                                                                                                                                     
razeedash     at readableAddChunk (_stream_readable.js:271:9)                                                                                                                                                                              
razeedash     at Socket.Readable.push (_stream_readable.js:212:10)                                                                                                                                                                         
razeedash     at TCP.onStreamRead (internal/stream_base_commons.js:186:23) {                                                                                                                                                               
razeedash   ok: 0,                                                                                                                                                                                                                         
razeedash   errmsg: 'Index: { v: 2, key: { _fts: "text", _ftsx: 1 }, name: "cluster_id_text_searchableData.name_text_searchableData.namespace_text", weights: { cluster_id: 1, cluster_name: 1, searchableData.kind: 1, searchableData.nam 
razeedash   code: 85,                                                                                                                                                                                                                      
razeedash   codeName: 'IndexOptionsConflict',                                                                                                                                                                                              
razeedash   [Symbol(mongoErrorContextSymbol)]: {}                                                                                                                                                                                          
razeedash }
```