### PR TITLE
Fix: allow tlsCAFile to be passed in from MONGO_OPTIONS

### DIFF
--- a/kubernetes/razeedash/resource.yaml
+++ b/kubernetes/razeedash/resource.yaml
@@ -36,6 +36,10 @@ items:
           securityContext:
             fsGroup: 999
             runAsUser: 999
+          volumes:
+            - name: razeedash-secret-vol
+              secret:
+                secretName: razeedash-secret
           containers:
             - env:
                 - name: MONGO_URL
@@ -94,6 +98,9 @@ items:
               image: "quay.io/razee/razeedash:{{TRAVIS_TAG}}"
               workingDir: /app
               imagePullPolicy: Always
+              volumeMounts:
+              - mountPath: /var/run/secrets/razeeio/razeedash-secret          
+                name: razeedash-secret-vol
               name: razeedash
               ports:
                 - containerPort: 3000

--- a/package-lock.json
+++ b/package-lock.json
@@ -191,9 +191,9 @@
       "dev": true
     },
     "@babel/runtime": {
-      "version": "7.10.5",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.10.5.tgz",
-      "integrity": "sha512-otddXKhdNn7d0ptoFRHtMLa8LqDxLYwTjB4nYgM1yy5N6gU/MUf8zqyyLltCH3yAVitBzmwK4us+DD0l/MauAg==",
+      "version": "7.11.2",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.11.2.tgz",
+      "integrity": "sha512-TeWkU52so0mPtDcaCTxNBI/IHiz0pZgr8VEFqXFtZWpYD08ZB6FaSwVAS8MKRQAP3bYKiVjwysOJgMFY28o6Tw==",
       "requires": {
         "regenerator-runtime": "^0.13.4"
       }
@@ -465,9 +465,9 @@
       "dev": true
     },
     "ace-builds": {
-      "version": "1.4.11",
-      "resolved": "https://registry.npmjs.org/ace-builds/-/ace-builds-1.4.11.tgz",
-      "integrity": "sha512-keACH1d7MvAh72fE/us36WQzOFQPJbHphNpj33pXwVZOM84pTWcdFzIAvngxOGIGLTm7gtUP2eJ4Ku6VaPo8bw=="
+      "version": "1.4.12",
+      "resolved": "https://registry.npmjs.org/ace-builds/-/ace-builds-1.4.12.tgz",
+      "integrity": "sha512-G+chJctFPiiLGvs3+/Mly3apXTcfgE45dT5yp12BcWZ1kUs+gm0qd3/fv4gsz6fVag4mM0moHVpjHDIgph6Psg=="
     },
     "acorn": {
       "version": "7.3.1",
@@ -797,9 +797,9 @@
       }
     },
     "bootstrap": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-4.5.0.tgz",
-      "integrity": "sha512-Z93QoXvodoVslA+PWNdk23Hze4RBYIkpb5h8I2HY2Tu2h7A0LpAgLcyrhrSUyo2/Oxm2l1fRZPs1e5hnxnliXA=="
+      "version": "4.5.2",
+      "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-4.5.2.tgz",
+      "integrity": "sha512-vlGn0bcySYl/iV+BGA544JkkZP5LB3jsmkeKLFQakCOwCM3AOk7VkldBz4jrzSe+Z0Ezn99NVXa1o45cQY4R6A=="
     },
     "bootstrap-datepicker": {
       "version": "1.9.0",
@@ -810,9 +810,9 @@
       }
     },
     "bootstrap-select": {
-      "version": "1.13.17",
-      "resolved": "https://registry.npmjs.org/bootstrap-select/-/bootstrap-select-1.13.17.tgz",
-      "integrity": "sha512-LbzSQumoZNYGuoYMpShKIHbJ2qUWFLI0qVHVeKqw5+nfhtMxz+Gre1+IuI3X74bTzQfalBqDKc8fS8tZMdciWg=="
+      "version": "1.13.18",
+      "resolved": "https://registry.npmjs.org/bootstrap-select/-/bootstrap-select-1.13.18.tgz",
+      "integrity": "sha512-V1IzK4rxBq5FrJtkzSH6RmFLFBsjx50byFbfAf8jYyXROWs7ZpprGjdHeoyq2HSsHyjJhMMwjsQhRoYAfxCGow=="
     },
     "boxen": {
       "version": "4.2.0",
@@ -3119,9 +3119,9 @@
       }
     },
     "meteor-node-stubs": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/meteor-node-stubs/-/meteor-node-stubs-1.0.0.tgz",
-      "integrity": "sha512-QJwyv23wyXD3uEMzk5Xr/y5ezoVlCbHvBbrgdkVadn84dmifLRbs0PtD6EeNw5NLIk+SQSfxld7IMdEsneGz5w==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/meteor-node-stubs/-/meteor-node-stubs-1.0.1.tgz",
+      "integrity": "sha512-I4PE/z7eAl45XEsebHA4pcQbgjqEdK3EBGgiUoIZBi3bMQcMq6blLWZo+WdtK4Or9X4NJOiYWw4GmHiubr3egA==",
       "requires": {
         "assert": "^1.4.1",
         "browserify-zlib": "^0.2.0",
@@ -3235,22 +3235,6 @@
             "elliptic": "^6.0.0",
             "inherits": "^2.0.1",
             "parse-asn1": "^5.0.0"
-          },
-          "dependencies": {
-            "elliptic": {
-              "version": "6.5.3",
-              "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.3.tgz",
-              "integrity": "sha512-IMqzv5wNQf+E6aHeIqATs0tOLeOTwj1QKbRcS3jBbYkl5oLAserA8yJTT7/VyHUYG91PRmPyeQDObKLPpeS4dw==",
-              "requires": {
-                "bn.js": "^4.4.0",
-                "brorand": "^1.0.1",
-                "hash.js": "^1.0.0",
-                "hmac-drbg": "^1.0.0",
-                "inherits": "^2.0.1",
-                "minimalistic-assert": "^1.0.0",
-                "minimalistic-crypto-utils": "^1.0.0"
-              }
-            }
           }
         },
         "browserify-zlib": {
@@ -3305,22 +3289,6 @@
           "requires": {
             "bn.js": "^4.1.0",
             "elliptic": "^6.0.0"
-          },
-          "dependencies": {
-            "elliptic": {
-              "version": "6.5.3",
-              "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.3.tgz",
-              "integrity": "sha512-IMqzv5wNQf+E6aHeIqATs0tOLeOTwj1QKbRcS3jBbYkl5oLAserA8yJTT7/VyHUYG91PRmPyeQDObKLPpeS4dw==",
-              "requires": {
-                "bn.js": "^4.4.0",
-                "brorand": "^1.0.1",
-                "hash.js": "^1.0.0",
-                "hmac-drbg": "^1.0.0",
-                "inherits": "^2.0.1",
-                "minimalistic-assert": "^1.0.0",
-                "minimalistic-crypto-utils": "^1.0.0"
-              }
-            }
           }
         },
         "create-hash": {
@@ -3390,8 +3358,7 @@
         },
         "elliptic": {
           "version": "6.5.3",
-          "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.3.tgz",
-          "integrity": "sha512-IMqzv5wNQf+E6aHeIqATs0tOLeOTwj1QKbRcS3jBbYkl5oLAserA8yJTT7/VyHUYG91PRmPyeQDObKLPpeS4dw==",
+          "bundled": true,
           "requires": {
             "bn.js": "^4.4.0",
             "brorand": "^1.0.1",
@@ -3913,12 +3880,6 @@
         }
       }
     },
-    "nested-error-stacks": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/nested-error-stacks/-/nested-error-stacks-2.0.1.tgz",
-      "integrity": "sha512-SrQrok4CATudVzBS7coSz26QRSmlK9TzzoFbeKfcPBUFPjcQM9Rqvr/DlJkOrwI/0KcgvMub1n1g5Jt9EgRn4A==",
-      "dev": true
-    },
     "nice-try": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
@@ -4106,26 +4067,25 @@
       }
     },
     "npm-check-updates": {
-      "version": "7.0.2",
-      "resolved": "https://registry.npmjs.org/npm-check-updates/-/npm-check-updates-7.0.2.tgz",
-      "integrity": "sha512-MyH17fUCFbYShuIyxZj6yqB6YZ47+AjPCgXQiH1oqNe3vElBoJ0toY7nwy88qJbfXnFqjTFigzs9lsoKSK0iUw==",
+      "version": "7.0.4",
+      "resolved": "https://registry.npmjs.org/npm-check-updates/-/npm-check-updates-7.0.4.tgz",
+      "integrity": "sha512-k3qcNK6hDJzPiRmszGb0NbkrCzVGk90hUQiszTVySilbocMuG+EGwsPFfICjpbce9nOTDDjvHvf6liS5i3UZNw==",
       "dev": true,
       "requires": {
         "chalk": "^4.1.0",
         "cint": "^8.2.1",
         "cli-table": "^0.3.1",
-        "commander": "^5.1.0",
+        "commander": "^6.0.0",
         "find-up": "4.1.0",
         "get-stdin": "^8.0.0",
         "json-parse-helpfulerror": "^1.0.3",
         "libnpmconfig": "^1.2.1",
         "lodash": "^4.17.19",
         "p-map": "^4.0.0",
-        "pacote": "^11.1.10",
+        "pacote": "^11.1.11",
         "progress": "^2.0.3",
         "prompts": "^2.3.2",
         "rc-config-loader": "^3.0.0",
-        "requireg": "^0.2.2",
         "semver": "^7.3.2",
         "semver-utils": "^1.1.4",
         "spawn-please": "^0.3.0",
@@ -4168,9 +4128,9 @@
           "dev": true
         },
         "commander": {
-          "version": "5.1.0",
-          "resolved": "https://registry.npmjs.org/commander/-/commander-5.1.0.tgz",
-          "integrity": "sha512-P0CysNDQ7rtVw4QIQtm+MRxV66vKFSvlsQvGYXZWR3qFU0jlMKHZZZgw8e+8DSah4UDKMqnknRDQz+xuQXQ/Zg==",
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-6.0.0.tgz",
+          "integrity": "sha512-s7EA+hDtTYNhuXkTlhqew4txMZVdszBmKWSPEMxGr8ru8JXR7bLUFIAtPhcSuFdJQ0ILMxnJi8GkQL0yvDy/YA==",
           "dev": true
         },
         "get-stdin": {
@@ -5007,9 +4967,9 @@
       }
     },
     "regenerator-runtime": {
-      "version": "0.13.5",
-      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.5.tgz",
-      "integrity": "sha512-ZS5w8CpKFinUzOwW3c83oPeVXoNsrLsaCoLtJvAClH135j/R77RuymhiSErhm2lKcwSCIpmvIWSbDkIfAqKQlA=="
+      "version": "0.13.7",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.7.tgz",
+      "integrity": "sha512-a54FxoJDIr27pgf7IgeQGxmqUNYrcV338lf/6gH456HZ/PhX+5BcwHXG9ajESmwe6WRO0tAzRUrRmNONWgkrew=="
     },
     "regexp.prototype.flags": {
       "version": "1.3.0",
@@ -5085,28 +5045,6 @@
       "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
       "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
       "dev": true
-    },
-    "requireg": {
-      "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/requireg/-/requireg-0.2.2.tgz",
-      "integrity": "sha512-nYzyjnFcPNGR3lx9lwPPPnuQxv6JWEZd2Ci0u9opN7N5zUEPIhY/GbL3vMGOr2UXwEg9WwSyV9X9Y/kLFgPsOg==",
-      "dev": true,
-      "requires": {
-        "nested-error-stacks": "~2.0.1",
-        "rc": "~1.2.7",
-        "resolve": "~1.7.1"
-      },
-      "dependencies": {
-        "resolve": {
-          "version": "1.7.1",
-          "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.7.1.tgz",
-          "integrity": "sha512-c7rwLofp8g1U+h1KNyHL/jicrKg1Ek4q+Lr33AL65uZTinUZHe30D5HlyN5V9NW0JX1D5dXQ4jqW5l7Sy/kGfw==",
-          "dev": true,
-          "requires": {
-            "path-parse": "^1.0.5"
-          }
-        }
-      }
     },
     "resolve": {
       "version": "1.17.0",

--- a/package.json
+++ b/package.json
@@ -11,11 +11,7 @@
             }
         }
     },
-    "resolutions": {
-        "elliptic": "^6.5.3"
-    },
     "scripts": {
-        "preinstall": "npx npm-force-resolutions",
         "start": "meteor run",
         "debug": "meteor run --inspect",
         "lint": "run-s eslint yamllint jsonlint dockerlint markdownlint shellcheck",
@@ -37,17 +33,17 @@
     "license": "Apache-2.0",
     "description": "Dashboard for razee resources",
     "dependencies": {
-        "@babel/runtime": "^7.10.5",
-        "ace-builds": "^1.4.11",
+        "@babel/runtime": "^7.11.2",
+        "ace-builds": "^1.4.12",
         "apollo-boost": "^0.4.7",
         "apollo-cache-inmemory": "^1.6.5",
         "apollo-client": "^2.6.8",
         "apollo-link": "^1.2.14",
         "apollo-link-error": "^1.1.13",
         "apollo-link-http": "^1.5.17",
-        "bootstrap": "^4.4.1",
+        "bootstrap": "^4.5.2",
         "bootstrap-datepicker": "^1.7.1",
-        "bootstrap-select": "^1.13.17",
+        "bootstrap-select": "^1.13.18",
         "clipboard": "^2.0.6",
         "color-hash": "^1.0.3",
         "core-js": "^3.6.4",
@@ -60,7 +56,7 @@
         "jwt-decode": "^2.2.0",
         "keypair": "^1.0.1",
         "lodash": "^4.17.19",
-        "meteor-node-stubs": "^1.0.0",
+        "meteor-node-stubs": "^1.0.1",
         "moment": "^2.27.0",
         "moment-duration-format": "^2.3.2",
         "mustache": "^4.0.0",
@@ -86,7 +82,7 @@
         "eslint": "^7.6.0",
         "jsonlint": "^1.6.3",
         "markdownlint-cli": "^0.23.2",
-        "npm-check-updates": "^7.0.2",
+        "npm-check-updates": "^7.0.4",
         "npm-run-all": "^4.1.5",
         "shellcheck": "^0.4.4",
         "sinon": "^9.0.2",


### PR DESCRIPTION
This will let users set a `tlsCAFile` option in their `MONGO_OPTIONS` config-map like this:
```shell
 MONGO_OPTIONS: '{"ssl": true, "tlsCAFile": "/var/run/secrets/razeeio/razeedash-secret " }
```

which will fix the `self signed certificate in certificate chain` error seen when connecting to a hosted mongo instance with razeedash