### PR TITLE
fix: allow self-signed ingress certificates to be trusted

### DIFF
--- a/kubernetes/razeedash/resource.yaml
+++ b/kubernetes/razeedash/resource.yaml
@@ -42,6 +42,8 @@ items:
                 secretName: razeedash-secret
           containers:
             - env:
+                - name: NODE_EXTRA_CA_CERTS
+                  value: /var/run/secrets/razeeio/razeedash-secret/cacerts.pem
                 - name: MONGO_URL
                   valueFrom:
                     secretKeyRef:


### PR DESCRIPTION
By adding the `NODE_EXTRA_CA_CERTS` environment variable we can let razeedash trust self-signed certs which is needed if the ingress for your razeedash-api is self-signed. Otherwise you get the following:
![image](https://user-images.githubusercontent.com/23663785/115764355-74bc5c00-a373-11eb-9a7f-4516347dc8d2.png)


To enable this you just add your certificate to the `razeedash-secret` secret with the key cacerts.pem. If you don't have that key in your secrets Razee still starts up fine, just no additional certs being accepted